### PR TITLE
Config - getServerNames() : don't return an immutable list

### DIFF
--- a/src/studio/kdb/Config.java
+++ b/src/studio/kdb/Config.java
@@ -170,7 +170,7 @@ public class Config {
     }
 
     public List<String> getServerNames() {
-        return Arrays.asList(split(p.getProperty("Servers", "")));
+        return new ArrayList<>(Arrays.asList(split(p.getProperty("Servers", ""))));
     }
 
     private void setServerNames(List<String> names) {


### PR DESCRIPTION
Previous change was breaking some of the edit feature:

> Exception in thread "AWT-EventQueue-0" java.lang.UnsupportedOperationException: remove
	at java.base/java.util.Iterator.remove(Iterator.java:102)
	at java.base/java.util.AbstractCollection.remove(AbstractCollection.java:283)
	at studio.kdb.Config.removeServer(Config.java:252)
	at studio.ui.StudioPanel$18.actionPerformed(StudioPanel.java:1118)
