### PR TITLE
dz.2: Server List position/Server tree/Load old Config format/Toggle tree/list in Server List/Settings: hide server drop down

### DIFF
--- a/src/studio/kdb/Config.java
+++ b/src/studio/kdb/Config.java
@@ -234,6 +234,15 @@ public class Config {
         save();
     }
 
+    public boolean isShowServerComboBox() {
+        return Boolean.parseBoolean(p.getProperty("showServerComboBox","true"));
+    }
+
+    public void setShowServerComboBox(boolean value) {
+        p.setProperty("showServerComboBox", "" + value);
+        save();
+    }
+
     public void setServerListBounds(Rectangle rectangle) {
         p.setProperty("serverList.x", "" + (int)rectangle.getX());
         p.setProperty("serverList.y", "" + (int)rectangle.getY());
@@ -281,7 +290,6 @@ public class Config {
     public ServerTreeNode getServerTree() {
         return serverTree;
     }
-
 
     private Server initServerFromKey(String key) {
         String host = p.getProperty("server." + key + ".host", "");

--- a/src/studio/kdb/Config.java
+++ b/src/studio/kdb/Config.java
@@ -2,6 +2,7 @@ package studio.kdb;
 
 import studio.core.Credentials;
 import studio.core.DefaultAuthenticationMechanism;
+import studio.ui.ServerList;
 
 import java.io.*;
 import java.nio.file.Files;
@@ -170,7 +171,7 @@ public class Config {
     }
 
     public List<String> getServerNames() {
-        return new ArrayList<>(Arrays.asList(split(p.getProperty("Servers", ""))));
+        return Arrays.asList(split(p.getProperty("Servers", "")));
     }
 
     private void setServerNames(List<String> names) {
@@ -248,7 +249,7 @@ public class Config {
         p.remove("server." + name + ".authenticationMechanism");
         p.remove("server." + name + ".useTLS");
 
-        List<String> list = getServerNames();
+        List<String> list = new ArrayList<>(getServerNames());
         list.remove(name);
         setServerNames(list);
     }
@@ -308,4 +309,37 @@ public class Config {
         p.setProperty("auth", authMechanism);
         save();
     }
+
+    public void setServerListBounds(Rectangle rectangle) {
+        p.setProperty("serverList.x", "" + (int)rectangle.getX());
+        p.setProperty("serverList.y", "" + (int)rectangle.getY());
+        p.setProperty("serverList.width", "" + (int)rectangle.getWidth());
+        p.setProperty("serverList.height", "" + (int)rectangle.getHeight());
+        save();
+    }
+
+    public Rectangle getServerListBounds() {
+        String strX = p.getProperty("serverList.x");
+        String strY = p.getProperty("serverList.y");
+        String strWidth = p.getProperty("serverList.width");
+        String strHeight = p.getProperty("serverList.height");
+
+        if (strX != null && strY != null && strWidth != null && strHeight != null) {
+            return new Rectangle(Integer.parseInt(strX), Integer.parseInt(strY),
+                                Integer.parseInt(strWidth), Integer.parseInt(strHeight));
+        }
+
+        DisplayMode displayMode = GraphicsEnvironment.getLocalGraphicsEnvironment()
+                                            .getDefaultScreenDevice().getDisplayMode();
+
+        int width = displayMode.getWidth();
+        int height = displayMode.getHeight();
+
+        int w = Math.min(width / 2, ServerList.DEFAULT_WIDTH);
+        int h = Math.min(height / 2, ServerList.DEFAULT_HEIGHT);
+        int x = (width - w) / 2;
+        int y = (height - h) / 2;
+        return new Rectangle(x,y,w,h);
+    }
+
 }

--- a/src/studio/kdb/Server.java
+++ b/src/studio/kdb/Server.java
@@ -2,7 +2,7 @@ package studio.kdb;
 
 import studio.core.Credentials;
 
-import java.awt.*;
+import java.awt.Color;
 import java.util.Objects;
 import java.util.Properties;
 
@@ -15,6 +15,7 @@ public class Server {
     private String username;
     private String password;
     private boolean useTLS = false;
+    private ServerTreeNode folder = null;
 
     public Properties getAsProperties() {
         Properties p = new Properties();
@@ -126,6 +127,13 @@ public class Server {
         return name;
     }
 
+    public String getFullName() {
+        if (folder == null) return name;
+        String path = folder.fullPath();
+        if (path.length() == 0) return name;
+        return path + "/" + name;
+    }
+
     public String getHost() {
         return host;
     }
@@ -135,7 +143,7 @@ public class Server {
     }
 
     public String toString() {
-        return name;
+        return getFullName();
     }
 
     public String getConnectionString(boolean includeCreditional) {
@@ -146,7 +154,20 @@ public class Server {
 
     }
 
-    public boolean getUseTLS() {
-        return useTLS;
+    public String getDescription() {
+        return name + " (" + host + ":" + port + ")";
     }
+
+    public boolean getUseTLS(){
+      return useTLS;
+    }
+
+    public ServerTreeNode getFolder() {
+        return folder;
+    }
+
+    public void setFolder(ServerTreeNode folder) {
+        this.folder = folder;
+    }
+
 }

--- a/src/studio/kdb/Server.java
+++ b/src/studio/kdb/Server.java
@@ -154,8 +154,8 @@ public class Server {
 
     }
 
-    public String getDescription() {
-        return name + " (" + host + ":" + port + ")";
+    public String getDescription(boolean fullName) {
+        return (fullName ? getFullName() : name) + " (" + host + ":" + port + ")";
     }
 
     public boolean getUseTLS(){

--- a/src/studio/kdb/ServerTreeNode.java
+++ b/src/studio/kdb/ServerTreeNode.java
@@ -1,0 +1,168 @@
+package studio.kdb;
+
+import javax.swing.tree.DefaultMutableTreeNode;
+import javax.swing.tree.TreeNode;
+import java.util.Collections;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class ServerTreeNode extends DefaultMutableTreeNode {
+
+    public ServerTreeNode() {
+        this("");
+    }
+
+    public ServerTreeNode(Server server) {
+        super(server, false);
+    }
+
+    public ServerTreeNode(String folder) {
+        super(folder, true);
+    }
+
+    public ServerTreeNode copy() {
+        if (isFolder()) {
+            ServerTreeNode parent = new ServerTreeNode(getFolder());
+            for (ServerTreeNode child: childNodes()) {
+                parent.add(child.copy());
+            }
+            return parent;
+        } else {
+            return new ServerTreeNode(getServer());
+        }
+    }
+
+    public boolean isFolder() {
+        return allowsChildren;
+    }
+
+    public Server getServer() {
+        if (isFolder()) {
+            throw new IllegalArgumentException("This node is not server");
+        }
+        return (Server)userObject;
+    }
+
+    public String getFolder() {
+        if (!isFolder()) {
+            throw new IllegalArgumentException("This node is server");
+        }
+        return (String)userObject;
+    }
+
+    public ServerTreeNode add(Server server) {
+        return add(getChildCount(), server);
+    }
+
+    public ServerTreeNode add(String folder) {
+        return add(getChildCount(), folder);
+    }
+
+    public ServerTreeNode add(int index, Server server) {
+        if (!isFolder()) {
+            throw new IllegalArgumentException("Server node can be added only to folders");
+        }
+        ServerTreeNode serverTreeNode = new ServerTreeNode(server);
+        insert(serverTreeNode, index);
+        return serverTreeNode;
+    }
+
+    public ServerTreeNode add(int index, String folder) {
+        if (!isFolder()) {
+            throw new IllegalArgumentException("Folder node can be added only to folders");
+        }
+        ServerTreeNode serverTreeNode = new ServerTreeNode(folder);
+        insert(serverTreeNode, index);
+        return serverTreeNode;
+    }
+
+    // Remove direct child
+    public boolean remove(Server server) {
+        if (!isFolder()) {
+            throw new IllegalArgumentException("This is not folder");
+        }
+        int count = getChildCount();
+        for (int index=0; index<count; index++) {
+            ServerTreeNode treeNode = getChild(index);
+            if (treeNode.isFolder()) continue;
+            if (treeNode.getServer().equals(server)) {
+                remove(index);
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public ServerTreeNode getChild(String folder) {
+        for(ServerTreeNode child: childNodes()) {
+            if (child.isFolder() && child.getFolder().equals(folder)) return child;
+        }
+        return null;
+    }
+
+    public ServerTreeNode getChild(Server server) {
+        for(ServerTreeNode child: childNodes()) {
+            if (!child.isFolder() && child.getServer().equals(server)) return child;
+        }
+        return null;
+    }
+
+    public ServerTreeNode getChild(int index) {
+        return (ServerTreeNode) getChildAt(index);
+    }
+
+    public Iterable<ServerTreeNode> childNodes() {
+        if (children != null) return children;
+        return Collections.emptyList();
+    }
+
+    // Recursively find ServerTreeNode with passed Server
+    public ServerTreeNode findServerNode(Server server) {
+        if (isFolder()) {
+            for(ServerTreeNode child: childNodes()) {
+                ServerTreeNode node = child.findServerNode(server);
+                if (node != null) return node;
+            }
+        } else {
+            if (getServer().equals(server)) return this;
+        }
+
+        return null;
+    }
+
+    // Find in current tree the path from potentially a different tree
+    public ServerTreeNode findPath(TreeNode[] nodes) {
+        return findPath(nodes, 0);
+    }
+
+    private ServerTreeNode findPath(TreeNode[] nodes, int head) {
+        if (! theSame( (ServerTreeNode)nodes[head])) return null;
+        if (head == nodes.length-1) return this;
+
+        for (ServerTreeNode child: childNodes()) {
+            ServerTreeNode node = child.findPath(nodes, head+1);
+            if (node != null) return node;
+        }
+        return null;
+    }
+
+
+    public boolean theSame(ServerTreeNode that) {
+        if (isFolder()) {
+            if (! that.isFolder()) return false;
+            return getFolder().equals(that.getFolder());
+        } else {
+            if (that.isFolder()) return false;
+            return getServer().equals(that.getServer());
+        }
+    }
+
+    @Override
+    public String toString() {
+        return isFolder() ? getFolder() : getServer().toString();
+    }
+
+    public String fullPath() {
+        return Stream.of(getPath()).skip(1).map(n->n.toString()).collect(Collectors.joining("/"));
+    }
+}

--- a/src/studio/kdb/TableHeaderRenderer.java
+++ b/src/studio/kdb/TableHeaderRenderer.java
@@ -48,20 +48,20 @@ public class TableHeaderRenderer extends DefaultTableCellRenderer {
             if (ktm.isSortedDesc()) {
                 if (column == ktm.getSortByColumn())
                     if (ktm.getColumnClass(column) == K.KSymbolVector.class)
-                        icon = new ScaledIcon(Util.getImage(Config.imageBase + "sort_az_ascending.png"),targetHeight);
+                        icon = new ScaledIcon(Util.SORT_AZ_ASC_ICON,targetHeight);
                     else
-                        icon = new ScaledIcon(Util.getImage(Config.imageBase + "sort_descending.png"),targetHeight);
+                        icon = new ScaledIcon(Util.SORT_DESC_ICON,targetHeight);
             }
             else if (ktm.isSortedAsc())
                 if (column == ktm.getSortByColumn())
                     if (ktm.getColumnClass(column) == K.KSymbolVector.class)
-                        icon = new ScaledIcon(Util.getImage(Config.imageBase + "sort_az_descending.png"),targetHeight);
+                        icon = new ScaledIcon(Util.SORT_AZ_DESC_ICON,targetHeight);
                     else
-                        icon = new ScaledIcon(Util.getImage(Config.imageBase + "sort_ascending.png"),targetHeight);
+                        icon = new ScaledIcon(Util.SORT_ASC_ICON,targetHeight);
             if (icon != null)
                 setIcon(icon);
             else {
-                icon = new ScaledIcon(Util.getImage(Config.imageBase + "sort_ascending.png"),targetHeight);
+                icon = new ScaledIcon(Util.SORT_ASC_ICON,targetHeight);
                 setIcon(new BlankIcon(icon));
             }
         }

--- a/src/studio/qeditor/QCompletionQuery.java
+++ b/src/studio/qeditor/QCompletionQuery.java
@@ -66,7 +66,7 @@ public class QCompletionQuery implements CompletionQuery
                                      result.add(new BooleanAttribItem(((K.KSymbol)tables.at(i)).s, offset, 0, false));
                                  }
 
-                                 currentIcon= Util.getImage(Config.imageBase2+"column.png");
+                                 currentIcon= Util.COLUMN_ICON;
 
                                  r = new CompletionQuery.DefaultResult(component, "Columns", result, offset, 0);
                              }
@@ -84,7 +84,7 @@ public class QCompletionQuery implements CompletionQuery
                                      result.add(new BooleanAttribItem(((K.KSymbol)tables.at(i)).s, offset, 0, false));
                                  }
 
-                                 currentIcon= Util.getImage(Config.imageBase2+"table.png");
+                                 currentIcon= Util.TABLE_ICON;
 
                                  r = new CompletionQuery.DefaultResult(component, "Tables", result, offset, 0);
                              }

--- a/src/studio/ui/AddServerForm.java
+++ b/src/studio/ui/AddServerForm.java
@@ -2,10 +2,10 @@ package studio.ui;
 
 import studio.kdb.Server;
 
-import javax.swing.JFrame;
+import java.awt.*;
 
 public class AddServerForm extends ServerForm {
-    public AddServerForm(JFrame owner) {
+    public AddServerForm(Window owner) {
         super(owner, "Add a new server", new Server());
     }
 }

--- a/src/studio/ui/EscapeDialog.java
+++ b/src/studio/ui/EscapeDialog.java
@@ -10,14 +10,18 @@ public abstract class EscapeDialog extends JDialog {
 
     private DialogResult result = DialogResult.CANCELLED;
 
-    public EscapeDialog(Frame owner,String title) {
-        super(owner,title, true);
+    public EscapeDialog(Window owner,String title) {
+        super(owner,title, ModalityType.APPLICATION_MODAL);
         initComponents();
     }
 
-    protected void alignAndShow() {
+    public void align() {
         pack();
         Util.centerChildOnParent(this, getParent());
+    }
+
+    public void alignAndShow() {
+        align();
         setVisible(true);
     }
 

--- a/src/studio/ui/ExcelExporter.java
+++ b/src/studio/ui/ExcelExporter.java
@@ -212,7 +212,7 @@ class ExcelExporter {
                             "\nThere was an error encoding the K types into Excel types.\n\n" + e.getMessage() + "\n\n",
                             "Studio for kdb+",
                             JOptionPane.OK_OPTION,
-                            Util.getImage(Config.imageBase + "32x32/error.png"));
+                            Util.ERROR_ICON);
                 } finally {
                     pm.close();
                 }
@@ -368,7 +368,7 @@ class ExcelExporter {
                     "\nThere was an error opening excel.\n\n" + e.getMessage() + "\n\nPerhaps you do not have Excel installed,\nor .xls files are not associated with Excel",
                     "Studio for kdb+",
                     JOptionPane.OK_OPTION,
-                    Util.getImage(Config.imageBase + "32x32/error.png"));
+                    Util.ERROR_ICON);
 
         }
     }

--- a/src/studio/ui/LineChart.java
+++ b/src/studio/ui/LineChart.java
@@ -33,7 +33,7 @@ public class LineChart {
 
             frame.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
 
-            frame.setIconImage(Util.getImage(Config.imageBase2 + "chart_24.png").getImage());
+            frame.setIconImage(Util.CHART_BIG_ICON.getImage());
 
             frame.pack();
             frame.setVisible(true);

--- a/src/studio/ui/QGrid.java
+++ b/src/studio/ui/QGrid.java
@@ -209,7 +209,7 @@ public class QGrid extends JPanel {
         this.add(scrollPane, BorderLayout.CENTER);
 
         UserAction copyExcelFormatAction = new UserAction("Copy (Excel format)",
-                Util.getImage(Config.imageBase2 + "copy.png"),
+                Util.COPY_ICON,
                 "Copy the selected cells to the clipboard using Excel format",
                 KeyEvent.VK_E,
                 null) {
@@ -259,7 +259,7 @@ public class QGrid extends JPanel {
         };
 
         UserAction copyHtmlFormatAction = new UserAction("Copy (HTML)",
-                Util.getImage(Config.imageBase2 + "copy.png"),
+                Util.COPY_ICON,
                 "Copy the selected cells to the clipboard using HTML",
                 KeyEvent.VK_H,
                 null) {

--- a/src/studio/ui/ServerForm.java
+++ b/src/studio/ui/ServerForm.java
@@ -5,13 +5,12 @@ import studio.core.Credentials;
 import studio.kdb.Config;
 import studio.kdb.Server;
 import studio.core.AuthenticationManager;
-import java.awt.Color;
+
+import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
-import java.io.IOException;
-import java.lang.reflect.InvocationTargetException;
 import javax.swing.*;
 
 import static javax.swing.GroupLayout.Alignment.*;
@@ -22,7 +21,7 @@ import static javax.swing.LayoutStyle.ComponentPlacement.RELATED;
 public class ServerForm extends EscapeDialog {
     private Server s;
 
-    public ServerForm(JFrame frame,String title, Server server){
+    public ServerForm(Window frame, String title, Server server){
         super(frame, title);
         s=new Server(server);
 
@@ -30,10 +29,7 @@ public class ServerForm extends EscapeDialog {
 
         logicalName.setText(s.getName());
         hostname.setText(s.getHost());
-        String u= s.getUsername();
-        if(u.trim().length()==0)
-            u=System.getProperty("user.name");
-        username.setText(u);
+        username.setText(s.getUsername());
         port.setText(""+s.getPort());
         password.setText(s.getPassword());
         jCheckBox2.setSelected(s.getUseTLS());

--- a/src/studio/ui/ServerList.java
+++ b/src/studio/ui/ServerList.java
@@ -1,104 +1,230 @@
 package studio.ui;
 
+import studio.kdb.Config;
 import studio.kdb.Server;
+import studio.kdb.ServerTreeNode;
 
 import javax.swing.*;
 import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
-import javax.swing.tree.DefaultMutableTreeNode;
+import javax.swing.event.TreeExpansionEvent;
+import javax.swing.event.TreeExpansionListener;
 import javax.swing.tree.DefaultTreeModel;
+import javax.swing.tree.TreeNode;
 import javax.swing.tree.TreePath;
 import javax.swing.tree.TreeSelectionModel;
 import java.awt.*;
-import java.awt.event.MouseAdapter;
-import java.awt.event.MouseEvent;
+import java.awt.event.*;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.StringTokenizer;
 
-public class ServerList extends EscapeDialog {
+public class ServerList extends EscapeDialog implements TreeExpansionListener  {
 
     private JTree tree;
+    private DefaultTreeModel treeModel;
     private JTextField filter;
-    private DefaultMutableTreeNode root;
+    private boolean ignoreExpansionListener = false;
+    private java.util.Set<TreePath> expandedPath = new HashSet<>();
+    private java.util.Set<TreePath> collapsedPath = new HashSet<>();
 
     private Server selectedServer;
     private Server activeServer;
-    private Server[] servers;
-    private java.util.List<String> filters = new ArrayList<>();
+    private ServerTreeNode serverTree, root;
+
+    private JPopupMenu popupMenu;
+    private UserAction selectAction, removeAction,
+                        insertFolderAction, insertServerAction,
+                        addServerBeforeAction, addServerAfterAction,
+                        addFolderBeforeAction, addFolderAfterAction;
 
     public final static int DEFAULT_WIDTH = 300;
     public final static int DEFAULT_HEIGHT = 400;
 
-    public ServerList(JFrame parent, Server[] servers, Server active) {
+    public ServerList(JFrame parent) {
         super(parent, "Server List");
         initComponents();
+    }
 
-        this.servers = servers;
-        this.activeServer = active;
-        selectedServer = active;
-
+    public void updateServerTree(ServerTreeNode serverTree, Server activeServer) {
+        this.serverTree = serverTree;
+        this.activeServer = activeServer;
+        selectedServer = activeServer;
         refreshServers();
     }
 
-    private void refreshFilters(String filterSting) {
+    //Split filter text by spaces
+    private java.util.List<String> getFilters() {
+        java.util.List<String> filters = new ArrayList<>();
         filters.clear();
-        StringTokenizer st = new StringTokenizer(filterSting," \t");
+        StringTokenizer st = new StringTokenizer(filter.getText()," \t");
         while (st.hasMoreTokens()) {
             String word = st.nextToken().trim();
             if (word.length()>0) filters.add(word.toLowerCase());
         }
+        return filters;
     }
 
-    private boolean filterServer(Server server) {
-        if (filters.size() == 0) return false;
-        if (server.equals(activeServer)) return false;
-        String name = server.getName().toLowerCase();
-        for(String filter:filters) {
-            if (! name.contains(filter)) return true;
-        }
-        return false;
+    private void setRoot(ServerTreeNode root) {
+        this.root = root;
+        treeModel.setRoot(root);
+        treeModel.reload();
     }
 
+    //Reload server tree
     private void refreshServers() {
-        root.removeAllChildren();
-        for (Server server:servers) {
-            if (filterServer(server)) continue;
-            ServerNode node = new ServerNode(server);
-            if (activeServer != null && activeServer.equals(server)) {
-                node.setActive(true);
+        java.util.List<String> filters = getFilters();
+        if (filters.size() > 0) {
+            setRoot(filter(serverTree, filters));
+            expandAll(); // expand all if we apply any filters
+        } else {
+            ignoreExpansionListener = true;
+            setRoot(serverTree);
+            //restore expanded state which was the last time (potentially was changed during filtering)
+            for (TreePath path: expandedPath) {
+                tree.expandPath(path);
             }
-            root.add(new DefaultMutableTreeNode(node));
+            for (TreePath path: collapsedPath) {
+                tree.collapsePath(path);
+            }
+            //Make sure that active server is expanded and visible
+            if (activeServer != null) {
+                ServerTreeNode folder = activeServer.getFolder();
+                if (folder != null) {
+                    ServerTreeNode node = folder.findServerNode(activeServer);
+                    if (node != null) {
+                        TreePath path = new TreePath(node.getPath());
+                        tree.expandPath(path.getParentPath());
+                        //validate before scrollPathToVisible is needed to layout all nodes
+                        tree.validate();
+                        tree.scrollPathToVisible(path);
+                    }
+                }
+            }
+            ignoreExpansionListener = false;
         }
-        tree.expandPath(new TreePath(root.getPath()));
-        ((DefaultTreeModel)tree.getModel()).reload();
         tree.invalidate();
+    }
+
+
+    private void expandAll() {
+        ServerTreeNode root = (ServerTreeNode)treeModel.getRoot();
+        if (root == null) return;
+        expandAll(root, new TreePath(root));
+    }
+
+    private void expandAll(ServerTreeNode parent, TreePath path) {
+        for(ServerTreeNode child:parent.childNodes() ) {
+            expandAll(child, path.pathByAddingChild(child));
+        }
+        tree.expandPath(path);
+    }
+
+    private ServerTreeNode filter(ServerTreeNode parent, java.util.List<String> filters) {
+        String value = parent.isFolder() ? parent.getFolder() : parent.getServer().getName();
+        value = value.toLowerCase();
+        java.util.List<String> left = new ArrayList<>();
+        for(String filter:filters) {
+            if (! value.contains(filter)) {
+                left.add(filter);
+            }
+        }
+
+        if (left.size() ==0) return parent.copy();
+
+        java.util.List<ServerTreeNode> children = new ArrayList<>();
+        for (ServerTreeNode child: parent.childNodes()) {
+            ServerTreeNode childFiltered = filter(child, left);
+            if (childFiltered != null) {
+                children.add(childFiltered);
+            }
+        }
+
+        if (children.size() == 0) return null;
+
+        ServerTreeNode result = new ServerTreeNode(parent.getFolder());
+        for (ServerTreeNode child: children) {
+            result.add(child);
+        }
+        return result;
     }
 
     public Server getSelectedServer() {
         return selectedServer;
     }
 
-    private void filterChanged() {
-        refreshFilters(filter.getText());
-        refreshServers();
+    @Override
+    public void treeExpanded(TreeExpansionEvent event) {
+        if (ignoreExpansionListener) return;
+        if (filter.getText().trim().length() > 0) return;
+
+        TreePath path = event.getPath();
+        collapsedPath.remove(path);
+        expandedPath.add(path);
+    }
+
+    @Override
+    public void treeCollapsed(TreeExpansionEvent event) {
+        if (ignoreExpansionListener) return;
+        if (filter.getText().trim().length() > 0) return;
+
+        TreePath path = event.getPath();
+        expandedPath.remove(path);
+        collapsedPath.add(path);
+    }
+
+    private void action() {
+        ServerTreeNode node  = (ServerTreeNode) tree.getLastSelectedPathComponent();
+        if (node == null) return; // no selection
+        if (node.isFolder()) return;
+        selectedServer = node.getServer();
+        accept();
     }
 
     private void initComponents() {
-        root = new DefaultMutableTreeNode("Servers");
-        tree = new JTree(root);
+        initPopupMenu();
+        treeModel = new DefaultTreeModel(new ServerTreeNode(), true);
+        tree = new JTree(treeModel) {
+            @Override
+            public String convertValueToText(Object nodeObj, boolean selected, boolean expanded, boolean leaf, int row, boolean hasFocus) {
+                ServerTreeNode node = (ServerTreeNode) nodeObj;
+                String value;
+                if (node.isFolder()) {
+                    value = node.getFolder();
+                } else {
+                    value = node.getServer().getDescription();
+                }
+                if (!node.isFolder() && node.getServer().equals(activeServer)) {
+                    value = "<html><b>" + value + "</b></html>";
+                }
+                return value;
+            }
+        };
         tree.setRootVisible(false);
-        tree.expandPath(new TreePath(root.getPath()));
         tree.setEditable(false);
         tree.getSelectionModel().setSelectionMode(TreeSelectionModel.SINGLE_TREE_SELECTION);
+        tree.addTreeExpansionListener(this);
         tree.addMouseListener(new MouseAdapter() {
             @Override
             public void mousePressed(MouseEvent e) {
-                if (e.getClickCount() != 2) return;
-                DefaultMutableTreeNode node  = (DefaultMutableTreeNode) tree.getLastSelectedPathComponent();
-                if (node == null) return; // no selection
-                if (! node.isLeaf()) return;
-                selectedServer = ((ServerNode) node.getUserObject()).getServer();
-                dispose();
+                if (e.isPopupTrigger()) {
+                    handlePopup(e);
+                } else if (e.getClickCount() == 2) {
+                    action();
+                }
+            }
+
+            @Override
+            public void mouseReleased(MouseEvent e) {
+                if (e.isPopupTrigger()) handlePopup(e);
+            }
+        });
+        tree.addKeyListener(new KeyAdapter() {
+            @Override
+            public void keyPressed(KeyEvent e) {
+                if (e.getKeyCode() == KeyEvent.VK_ENTER) {
+                    action();
+                }
             }
         });
         add(new JScrollPane(tree), BorderLayout.CENTER);
@@ -106,15 +232,15 @@ public class ServerList extends EscapeDialog {
         filter.getDocument().addDocumentListener(new DocumentListener() {
             @Override
             public void insertUpdate(DocumentEvent e) {
-                filterChanged();
+                refreshServers();
             }
             @Override
             public void removeUpdate(DocumentEvent e) {
-                filterChanged();
+                refreshServers();
             }
             @Override
             public void changedUpdate(DocumentEvent e) {
-                filterChanged();
+                refreshServers();
             }
         });
         add(filter, BorderLayout.NORTH);
@@ -122,23 +248,130 @@ public class ServerList extends EscapeDialog {
     }
 
 
-    private static class ServerNode {
-        private Server server;
-        private boolean active = false;
+    private void handlePopup(MouseEvent e) {
+        int x = e.getX();
+        int y = e.getY();
+        TreePath path = tree.getPathForLocation(x, y);
+        if (path == null) {
+            return;
+        };
 
-        ServerNode(Server server) {
-            this.server = server;
+        tree.setSelectionPath(path);
+        boolean isFolder = ((ServerTreeNode)path.getLastPathComponent()).isFolder();
+        insertServerAction.setEnabled(isFolder);
+        insertFolderAction.setEnabled(isFolder);
+
+        popupMenu.show(tree, x, y);
+    }
+
+    private void initPopupMenu() {
+        selectAction = UserAction.create("Select", "Select the node",
+                                                        KeyEvent.VK_S, (e) -> action());
+        removeAction = UserAction.create("Remove", "Remove the node",
+                                    KeyEvent.VK_DELETE, (e) -> removeNode());
+        insertServerAction = UserAction.create("Insert Server", "Insert server into the folder",
+                                    KeyEvent.VK_N, (e) -> addNode(false, AddNodeLocation.INSERT));
+        insertFolderAction = UserAction.create("Insert Folder", "Insert folder into the folder",
+                                    KeyEvent.VK_I, (e) -> addNode(true, AddNodeLocation.INSERT));
+        addServerBeforeAction = UserAction.create("Add Server Before", "Add Server before selected node",
+                                    KeyEvent.VK_R, (e) -> addNode(false, AddNodeLocation.BEFORE));
+        addServerAfterAction = UserAction.create("Add Server After", "Add Server after selected node",
+                                    KeyEvent.VK_E, (e) -> addNode(false, AddNodeLocation.AFTER));
+        addFolderBeforeAction = UserAction.create("Add Folder Before", "Add Folder before selected node",
+                                    KeyEvent.VK_B, (e) -> addNode(true, AddNodeLocation.BEFORE));
+        addFolderAfterAction = UserAction.create("Add Folder After", "Add Folder after selected node",
+                                    KeyEvent.VK_A, (e) -> addNode(true, AddNodeLocation.AFTER));
+
+        popupMenu = new JPopupMenu();
+        popupMenu.add(selectAction);
+        popupMenu.add(new JSeparator());
+        popupMenu.add(insertFolderAction);
+        popupMenu.add(addFolderBeforeAction);
+        popupMenu.add(addFolderAfterAction);
+        popupMenu.add(new JSeparator());
+        popupMenu.add(insertServerAction);
+        popupMenu.add(addServerBeforeAction);
+        popupMenu.add(addServerAfterAction);
+        popupMenu.add(new JSeparator());
+        popupMenu.add(removeAction);
+    }
+
+    private void removeNode() {
+        ServerTreeNode selNode  = (ServerTreeNode) tree.getLastSelectedPathComponent();
+        if (selNode == null) return;
+        ServerTreeNode node = serverTree.findPath(selNode.getPath());
+        if (node == null) {
+            System.err.println("Ups... Something goes wrong");
+            return;
         }
-        Server getServer() {return server;}
-        void setActive(boolean active) {this.active = active;}
 
-        @Override
-        public String toString() {
-            if (active) {
-                return "<html><b>" + server.getName() + "</b></html>";
-            } else {
-                return server.getName();
-            }
+        String message = "Are you sure you want to remove " + (node.isRoot() ? "folder" : "server") + ": " + node.fullPath();
+        int result = JOptionPane.showConfirmDialog(this, message, "Remove?", JOptionPane.YES_NO_OPTION, JOptionPane.WARNING_MESSAGE);
+        if (result != JOptionPane.YES_OPTION) return;
+
+        TreeNode[] path = ((ServerTreeNode)selNode.getParent()).getPath();
+        node.removeFromParent();
+        Config.getInstance().setServerTree(serverTree);
+        refreshServers();
+
+        TreePath treePath = new TreePath(path);
+        tree.scrollPathToVisible(treePath);
+        tree.setSelectionPath(treePath);
+    }
+
+    private enum AddNodeLocation {INSERT, BEFORE, AFTER};
+
+    private void addNode(boolean folder, AddNodeLocation location) {
+        ServerTreeNode selNode  = (ServerTreeNode) tree.getLastSelectedPathComponent();
+        if (selNode == null) return;
+
+        ServerTreeNode node = serverTree.findPath(selNode.getPath());
+        if (node == null) {
+            System.err.println("Ups... Something goes wrong");
+            return;
+        }
+        ServerTreeNode parent = location == AddNodeLocation.INSERT ? node : (ServerTreeNode)node.getParent();
+
+        ServerTreeNode newNode;
+        if (folder) {
+            String name = JOptionPane.showInputDialog(this, "Enter folder name", "Folder Name", JOptionPane.QUESTION_MESSAGE);
+            if (name == null || name.trim().length() == 0) return;
+            newNode = new ServerTreeNode(name);
+        } else {
+            AddServerForm addServerForm = new AddServerForm(this);
+            addServerForm.alignAndShow();
+            if (addServerForm.getResult() == DialogResult.CANCELLED) return;
+            Server server = addServerForm.getServer();
+            server.setFolder(parent);
+            newNode = new ServerTreeNode(server);
+        }
+
+        int index;
+        if (location == AddNodeLocation.INSERT) {
+            index = node.getChildCount();
+        } else {
+            index = parent.getIndex(node);
+            if (location == AddNodeLocation.AFTER) index++;
+        }
+
+        parent.insert(newNode, index);
+        try {
+            Config.getInstance().setServerTree(serverTree);
+        } catch (IllegalArgumentException exception) {
+            serverTree = Config.getInstance().getServerTree();
+            System.err.println("Error adding new node: " + exception);
+            exception.printStackTrace(System.err);
+            JOptionPane.showMessageDialog(this, "Error adding new node:\n" + exception.toString(), "Error", JOptionPane.ERROR_MESSAGE);
+
+        }
+        refreshServers();
+
+        selNode = root.findPath(newNode.getPath());
+        if (selNode != null) {
+            TreePath treePath = new TreePath(selNode.getPath());
+            tree.scrollPathToVisible(treePath);
+            tree.setSelectionPath(treePath);
         }
     }
+
 }

--- a/src/studio/ui/ServerList.java
+++ b/src/studio/ui/ServerList.java
@@ -10,8 +10,6 @@ import javax.swing.tree.DefaultTreeModel;
 import javax.swing.tree.TreePath;
 import javax.swing.tree.TreeSelectionModel;
 import java.awt.*;
-import java.awt.event.KeyAdapter;
-import java.awt.event.KeyEvent;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.util.ArrayList;
@@ -24,9 +22,12 @@ public class ServerList extends EscapeDialog {
     private DefaultMutableTreeNode root;
 
     private Server selectedServer;
-    private final Server activeServer;
-    private final Server[] servers;
-    private final java.util.List<String> filters = new ArrayList<>();
+    private Server activeServer;
+    private Server[] servers;
+    private java.util.List<String> filters = new ArrayList<>();
+
+    public final static int DEFAULT_WIDTH = 300;
+    public final static int DEFAULT_HEIGHT = 400;
 
     public ServerList(JFrame parent, Server[] servers, Server active) {
         super(parent, "Server List");
@@ -41,10 +42,10 @@ public class ServerList extends EscapeDialog {
 
     private void refreshFilters(String filterSting) {
         filters.clear();
-        StringTokenizer st = new StringTokenizer(filterSting, " \t");
+        StringTokenizer st = new StringTokenizer(filterSting," \t");
         while (st.hasMoreTokens()) {
             String word = st.nextToken().trim();
-            if (word.length() > 0) filters.add(word.toLowerCase());
+            if (word.length()>0) filters.add(word.toLowerCase());
         }
     }
 
@@ -52,15 +53,15 @@ public class ServerList extends EscapeDialog {
         if (filters.size() == 0) return false;
         if (server.equals(activeServer)) return false;
         String name = server.getName().toLowerCase();
-        for (String filter : filters) {
-            if (!name.contains(filter)) return true;
+        for(String filter:filters) {
+            if (! name.contains(filter)) return true;
         }
         return false;
     }
 
     private void refreshServers() {
         root.removeAllChildren();
-        for (Server server : servers) {
+        for (Server server:servers) {
             if (filterServer(server)) continue;
             ServerNode node = new ServerNode(server);
             if (activeServer != null && activeServer.equals(server)) {
@@ -69,7 +70,7 @@ public class ServerList extends EscapeDialog {
             root.add(new DefaultMutableTreeNode(node));
         }
         tree.expandPath(new TreePath(root.getPath()));
-        ((DefaultTreeModel) tree.getModel()).reload();
+        ((DefaultTreeModel)tree.getModel()).reload();
         tree.invalidate();
     }
 
@@ -93,15 +94,11 @@ public class ServerList extends EscapeDialog {
             @Override
             public void mousePressed(MouseEvent e) {
                 if (e.getClickCount() != 2) return;
-                updateSelectedServer();
-            }
-        });
-        tree.addKeyListener(new KeyAdapter() {
-            @Override
-            public void keyPressed(KeyEvent e) {
-                if (e.getKeyCode() == KeyEvent.VK_ENTER) {
-                    updateSelectedServer();
-                }
+                DefaultMutableTreeNode node  = (DefaultMutableTreeNode) tree.getLastSelectedPathComponent();
+                if (node == null) return; // no selection
+                if (! node.isLeaf()) return;
+                selectedServer = ((ServerNode) node.getUserObject()).getServer();
+                dispose();
             }
         });
         add(new JScrollPane(tree), BorderLayout.CENTER);
@@ -111,45 +108,29 @@ public class ServerList extends EscapeDialog {
             public void insertUpdate(DocumentEvent e) {
                 filterChanged();
             }
-
             @Override
             public void removeUpdate(DocumentEvent e) {
                 filterChanged();
             }
-
             @Override
             public void changedUpdate(DocumentEvent e) {
                 filterChanged();
             }
         });
         add(filter, BorderLayout.NORTH);
-        setPreferredSize(new Dimension(300, 400));
-    }
-
-    private void updateSelectedServer() {
-        DefaultMutableTreeNode node = (DefaultMutableTreeNode) tree.getLastSelectedPathComponent();
-        if (node == null) return; // no selection
-        if (!node.isLeaf()) return;
-        selectedServer = ((ServerNode) node.getUserObject()).getServer();
-        dispose();
+        setPreferredSize(new Dimension(DEFAULT_WIDTH, DEFAULT_HEIGHT));
     }
 
 
     private static class ServerNode {
-        private final Server server;
+        private Server server;
         private boolean active = false;
 
         ServerNode(Server server) {
             this.server = server;
         }
-
-        Server getServer() {
-            return server;
-        }
-
-        void setActive(boolean active) {
-            this.active = active;
-        }
+        Server getServer() {return server;}
+        void setActive(boolean active) {this.active = active;}
 
         @Override
         public String toString() {

--- a/src/studio/ui/SettingsDialog.java
+++ b/src/studio/ui/SettingsDialog.java
@@ -13,6 +13,9 @@ public class SettingsDialog extends EscapeDialog {
     private JComboBox comboBoxAuthMechanism;
     private JTextField txtUser;
     private JPasswordField txtPassword;
+    private JCheckBox chBoxShowServerCombo;
+    private JButton btnOk;
+    private JButton btnCancel;
 
     private final static int FIELD_SIZE = 150;
 
@@ -33,11 +36,22 @@ public class SettingsDialog extends EscapeDialog {
         return new String(txtPassword.getPassword());
     }
 
+    public boolean isShowServerComboBox() {
+        return chBoxShowServerCombo.isSelected();
+    }
+
     private void refreshCredentials() {
         Credentials credentials = Config.getInstance().getDefaultCredentials(getDefaultAuthenticationMechanism());
 
         txtUser.setText(credentials.getUsername());
         txtPassword.setText(credentials.getPassword());
+        chBoxShowServerCombo.setSelected(Config.getInstance().isShowServerComboBox());
+    }
+
+    @Override
+    public void align() {
+        super.align();
+        btnOk.requestFocusInWindow();
     }
 
     private void initComponents() {
@@ -48,19 +62,22 @@ public class SettingsDialog extends EscapeDialog {
         comboBoxAuthMechanism = new JComboBox(AuthenticationManager.getInstance().getAuthenticationMechanisms());
         comboBoxAuthMechanism.getModel().setSelectedItem(Config.getInstance().getDefaultAuthMechanism());
         comboBoxAuthMechanism.addItemListener(e -> refreshCredentials());
-        refreshCredentials();
 
+        chBoxShowServerCombo = new JCheckBox("Show server drop down list in the toolbar");
         JLabel lblAuthMechanism = new JLabel("Authentication:");
         JLabel lblUser = new JLabel("  User:");
         JLabel lblPassword = new JLabel("  Password:");
 
         Component glue = Box.createGlue();
         Component glue1 = Box.createGlue();
-        JButton btnOk = new JButton("OK");
-        JButton btnCancel = new JButton("Cancel");
+
+        btnOk = new JButton("OK");
+        btnCancel = new JButton("Cancel");
 
         btnOk.addActionListener(e->accept());
         btnCancel.addActionListener(e->cancel());
+
+        refreshCredentials();
 
         GroupLayout layout = new GroupLayout(root);
         root.setLayout(layout);
@@ -69,6 +86,7 @@ public class SettingsDialog extends EscapeDialog {
 
         layout.setHorizontalGroup(
                 layout.createParallelGroup()
+                        .addComponent(chBoxShowServerCombo)
                         .addGroup(
                             layout.createSequentialGroup()
                                         .addComponent(lblAuthMechanism)
@@ -89,6 +107,7 @@ public class SettingsDialog extends EscapeDialog {
 
         layout.setVerticalGroup(
                 layout.createSequentialGroup()
+                    .addComponent(chBoxShowServerCombo)
                     .addGroup(
                         layout.createParallelGroup(GroupLayout.Alignment.BASELINE)
                                 .addComponent(lblAuthMechanism)

--- a/src/studio/ui/StudioPanel.java
+++ b/src/studio/ui/StudioPanel.java
@@ -174,7 +174,7 @@ public class StudioPanel extends JPanel implements Observer,WindowListener {
                 if (actions[i] instanceof BaseKit.CopyAction) {
                     copyAction = (BaseKit.CopyAction) actions[i];
                     copyAction.putValue(Action.SHORT_DESCRIPTION,"Copy the selected text to the clipboard");
-                    copyAction.putValue(Action.SMALL_ICON,getImage(Config.imageBase2 + "copy.png"));
+                    copyAction.putValue(Action.SMALL_ICON,Util.COPY_ICON);
                     copyAction.putValue(Action.NAME,I18n.getString("Copy"));
                     copyAction.putValue(Action.MNEMONIC_KEY,new Integer(KeyEvent.VK_C));
                     copyAction.putValue(Action.ACCELERATOR_KEY,KeyStroke.getKeyStroke(KeyEvent.VK_C,menuShortcutKeyMask));
@@ -182,7 +182,7 @@ public class StudioPanel extends JPanel implements Observer,WindowListener {
                 else if (actions[i] instanceof BaseKit.CutAction) {
                     cutAction = (BaseKit.CutAction) actions[i];
                     cutAction.putValue(Action.SHORT_DESCRIPTION,"Cut the selected text");
-                    cutAction.putValue(Action.SMALL_ICON,getImage(Config.imageBase2 + "cut.png"));
+                    cutAction.putValue(Action.SMALL_ICON,Util.CUT_ICON);
                     cutAction.putValue(Action.NAME,I18n.getString("Cut"));
                     cutAction.putValue(Action.MNEMONIC_KEY,new Integer(KeyEvent.VK_T));
                     cutAction.putValue(Action.ACCELERATOR_KEY,KeyStroke.getKeyStroke(KeyEvent.VK_X,menuShortcutKeyMask));
@@ -190,7 +190,7 @@ public class StudioPanel extends JPanel implements Observer,WindowListener {
                 else if (actions[i] instanceof BaseKit.PasteAction) {
                     pasteAction = (BaseKit.PasteAction) actions[i];
                     pasteAction.putValue(Action.SHORT_DESCRIPTION,"Paste text from the clipboard");
-                    pasteAction.putValue(Action.SMALL_ICON,getImage(Config.imageBase2 + "paste.png"));
+                    pasteAction.putValue(Action.SMALL_ICON,Util.PASTE_ICON);
                     pasteAction.putValue(Action.NAME,I18n.getString("Paste"));
                     pasteAction.putValue(Action.MNEMONIC_KEY,new Integer(KeyEvent.VK_P));
                     pasteAction.putValue(Action.ACCELERATOR_KEY,KeyStroke.getKeyStroke(KeyEvent.VK_V,menuShortcutKeyMask));
@@ -198,7 +198,7 @@ public class StudioPanel extends JPanel implements Observer,WindowListener {
                 else if (actions[i] instanceof ExtKit.FindAction) {
                     findAction = actions[i];
                     findAction.putValue(Action.SHORT_DESCRIPTION,"Find text in the document");
-                    findAction.putValue(Action.SMALL_ICON,getImage(Config.imageBase2 + "find.png"));
+                    findAction.putValue(Action.SMALL_ICON,Util.FIND_ICON);
                     findAction.putValue(Action.NAME,I18n.getString("Find"));
                     findAction.putValue(Action.MNEMONIC_KEY,new Integer(KeyEvent.VK_F));
                     findAction.putValue(Action.ACCELERATOR_KEY,KeyStroke.getKeyStroke(KeyEvent.VK_F,menuShortcutKeyMask));
@@ -206,7 +206,7 @@ public class StudioPanel extends JPanel implements Observer,WindowListener {
                 else if (actions[i] instanceof ExtKit.ReplaceAction) {
                     replaceAction = actions[i];
                     replaceAction.putValue(Action.SHORT_DESCRIPTION,"Replace text in the document");
-                    replaceAction.putValue(Action.SMALL_ICON,getImage(Config.imageBase2 + "replace.png"));
+                    replaceAction.putValue(Action.SMALL_ICON,Util.REPLACE_ICON);
                     replaceAction.putValue(Action.NAME,I18n.getString("Replace"));
                     replaceAction.putValue(Action.MNEMONIC_KEY,new Integer(KeyEvent.VK_R));
                     replaceAction.putValue(Action.ACCELERATOR_KEY,KeyStroke.getKeyStroke(KeyEvent.VK_R,menuShortcutKeyMask));
@@ -222,7 +222,7 @@ public class StudioPanel extends JPanel implements Observer,WindowListener {
                 else if (actions[i] instanceof ActionFactory.UndoAction) {
                     undoAction = (ActionFactory.UndoAction) actions[i];
                     undoAction.putValue(Action.SHORT_DESCRIPTION,"Undo the last change to the document");
-                    undoAction.putValue(Action.SMALL_ICON,getImage(Config.imageBase2 + "undo.png"));
+                    undoAction.putValue(Action.SMALL_ICON,Util.UNDO_ICON);
                     undoAction.putValue(Action.NAME,I18n.getString("Undo"));
                     undoAction.putValue(Action.MNEMONIC_KEY,new Integer(KeyEvent.VK_U));
                     undoAction.putValue(Action.ACCELERATOR_KEY,KeyStroke.getKeyStroke(KeyEvent.VK_Z,menuShortcutKeyMask));
@@ -230,7 +230,7 @@ public class StudioPanel extends JPanel implements Observer,WindowListener {
                 else if (actions[i] instanceof ActionFactory.RedoAction) {
                     redoAction = (ActionFactory.RedoAction) actions[i];
                     redoAction.putValue(Action.SHORT_DESCRIPTION,"Redo the last change to the document");
-                    redoAction.putValue(Action.SMALL_ICON,getImage(Config.imageBase2 + "redo.png"));
+                    redoAction.putValue(Action.SMALL_ICON,Util.REDO_ICON);
                     redoAction.putValue(Action.NAME,I18n.getString("Redo"));
                     redoAction.putValue(Action.MNEMONIC_KEY,new Integer(KeyEvent.VK_R));
                     redoAction.putValue(Action.ACCELERATOR_KEY,KeyStroke.getKeyStroke(KeyEvent.VK_Y,menuShortcutKeyMask));
@@ -697,7 +697,7 @@ public class StudioPanel extends JPanel implements Observer,WindowListener {
                                                           "Warning",
                                                           "You did not specify what format to export the file as.\n Cancelling data export",
                                                           JOptionPane.WARNING_MESSAGE,
-                                                          getImage(Config.imageBase + "32x32/warning.png"));
+                                                          Util.WARNING_ICON);
             /*                else {
             exportAsBin(exportFilename);
             }
@@ -708,7 +708,7 @@ public class StudioPanel extends JPanel implements Observer,WindowListener {
                                               "Error",
                                               "An error occurred whilst writing the export file.\n Details are: " + e.getMessage(),
                                               JOptionPane.ERROR_MESSAGE,
-                                              getImage(Config.imageBase + "32x32/error.png"));
+                                              Util.ERROR_ICON);
             }
             finally {
                 //            frame.setCursor(cursor);
@@ -753,7 +753,7 @@ public class StudioPanel extends JPanel implements Observer,WindowListener {
                                                       "Save changes?",
                                                       JOptionPane.YES_NO_CANCEL_OPTION,
                                                       JOptionPane.QUESTION_MESSAGE,
-                                                      getImage(Config.imageBase + "32x32/question.png"),
+                                                      Util.QUESTION_ICON,
                                                       null, // use standard button titles
                                                       null);      // no default selection
 
@@ -889,7 +889,7 @@ public class StudioPanel extends JPanel implements Observer,WindowListener {
                                                               "Overwrite?",
                                                               JOptionPane.YES_NO_CANCEL_OPTION,
                                                               JOptionPane.QUESTION_MESSAGE,
-                                                              getImage(Config.imageBase + "32x32/question.png"),
+                                                              Util.QUESTION_ICON,
                                                               null, // use standard button titles
                                                               null);      // no default selection
 
@@ -1014,7 +1014,7 @@ public class StudioPanel extends JPanel implements Observer,WindowListener {
 
     private void initActions() {
         newFileAction = new UserAction(I18n.getString("New"),
-                                       getImage(Config.imageBase2 + "document_new.png"),
+                                        Util.NEW_DOCUMENT_ICON,
                                        "Create a blank script",
                                        new Integer(KeyEvent.VK_N),
                                        null) {
@@ -1025,7 +1025,7 @@ public class StudioPanel extends JPanel implements Observer,WindowListener {
         };
 
         arrangeAllAction = new UserAction(I18n.getString("ArrangeAll"),
-                                          getImage(Config.imageBase2 + "blank.png"),
+                                           Util.BLANK_ICON,
                                           "Arrange all windows on screen",
                                           new Integer(KeyEvent.VK_A),
                                           null) {
@@ -1035,7 +1035,7 @@ public class StudioPanel extends JPanel implements Observer,WindowListener {
         };
     
         minMaxDividerAction = new UserAction(I18n.getString("MaximizeEditorPane"),
-                                             getImage(Config.imageBase2 + "blank.png"),
+                                             Util.BLANK_ICON,
                                              "Maximize editor pane",
                                              new Integer(KeyEvent.VK_M),
                                              KeyStroke.getKeyStroke(KeyEvent.VK_M,menuShortcutKeyMask)) {
@@ -1045,7 +1045,7 @@ public class StudioPanel extends JPanel implements Observer,WindowListener {
         };
 
         toggleDividerOrientationAction = new UserAction(I18n.getString("ToggleDividerOrientation"),
-                                                        getImage(Config.imageBase2 + "blank.png"),
+                                                         Util.BLANK_ICON,
                                                         "Toggle the window divider's orientation",
                                                         new Integer(KeyEvent.VK_C),
                                                         null) {
@@ -1055,7 +1055,7 @@ public class StudioPanel extends JPanel implements Observer,WindowListener {
         };
 
         closeFileAction = new UserAction(I18n.getString("Close"),
-                                         getImage(Config.imageBase2 + "blank.png"),
+                                         Util.BLANK_ICON,
                                          "Close current document",
                                          new Integer(KeyEvent.VK_C),
                                          null) {
@@ -1067,7 +1067,7 @@ public class StudioPanel extends JPanel implements Observer,WindowListener {
         };
 
         openFileAction = new UserAction(I18n.getString("Open"),
-                                        getImage(Config.imageBase2 + "folder.png"),
+                                        Util.FOLDER_ICON,
                                         "Open a script",
                                         new Integer(KeyEvent.VK_O),
                                         KeyStroke.getKeyStroke(KeyEvent.VK_O,menuShortcutKeyMask)) {
@@ -1077,7 +1077,7 @@ public class StudioPanel extends JPanel implements Observer,WindowListener {
         };
 
         openFileInNewWindowAction = new UserAction(I18n.getString("NewWindow"),
-                                                   getImage(Config.imageBase2 + "blank.png"),
+                                                   Util.BLANK_ICON,
                                                    "Open a new window",
                                                    new Integer(KeyEvent.VK_N),
                                                    KeyStroke.getKeyStroke(KeyEvent.VK_N, menuShortcutKeyMask) ) {
@@ -1087,7 +1087,7 @@ public class StudioPanel extends JPanel implements Observer,WindowListener {
         };
 
         serverListAction = new UserAction(I18n.getString("ServerList"),
-                getImage(Config.imageBase + "text_tree.png"),
+                Util.TEXT_TREE_ICON,
                 "Show sever list",
                 new Integer(KeyEvent.VK_L),
                 KeyStroke.getKeyStroke(KeyEvent.VK_L, menuShortcutKeyMask | Event.SHIFT_MASK) ) {
@@ -1104,17 +1104,15 @@ public class StudioPanel extends JPanel implements Observer,WindowListener {
                                 Rectangle bounds = Config.getInstance().getServerListBounds();
                                 bounds.translate(frame.getX(), frame.getY());
 
-                                serverList = new ServerList(frame, Config.getInstance().getServers(), server);
-
+                                serverList = new ServerList(frame);
                                 if (screenBounds != null && screenBounds.contains(bounds)) {
                                     serverList.setBounds(bounds);
-                                    serverList.setVisible(true);
                                 } else {
-                                    serverList.alignAndShow();
+                                    serverList.align();
                                 }
-                            } else {
-                                serverList.setVisible(true);
                             }
+                            serverList.updateServerTree(Config.getInstance().getServerTree(), server);
+                            serverList.setVisible(true);
 
                             Rectangle bounds = serverList.getBounds();
                             bounds.translate( -frame.getX(), -frame.getY());
@@ -1129,7 +1127,7 @@ public class StudioPanel extends JPanel implements Observer,WindowListener {
         };
 
         editServerAction = new UserAction(I18n.getString("Edit"),
-                                          getImage(Config.imageBase2 + "server_information.png"),
+                                          Util.SERVER_INFORMATION_ICON,
                                           "Edit the server details",
                                           new Integer(KeyEvent.VK_E),
                                           null) {
@@ -1158,7 +1156,7 @@ public class StudioPanel extends JPanel implements Observer,WindowListener {
 
 
         addServerAction = new UserAction(I18n.getString("Add"),
-                                         getImage(Config.imageBase2 + "server_add.png"),
+                                         Util.ADD_SERVER_ICON,
                                          "Configure a new server",
                                          new Integer(KeyEvent.VK_A),
                                          null) {
@@ -1178,17 +1176,17 @@ public class StudioPanel extends JPanel implements Observer,WindowListener {
         };
 
         removeServerAction = new UserAction(I18n.getString("Remove"),
-                                            getImage(Config.imageBase2 + "server_delete.png"),
+                                            Util.DELETE_SERVER_ICON,
                                             "Remove this server",
                                             new Integer(KeyEvent.VK_R),
                                             null) {
             public void actionPerformed(ActionEvent e) {
                 int choice = JOptionPane.showOptionDialog(frame,
-                                                          "Remove server " + server.getName() + " from list?",
+                                                          "Remove server " + server.getFullName() + " from list?",
                                                           "Remove server?",
                                                           JOptionPane.YES_NO_CANCEL_OPTION,
                                                           JOptionPane.QUESTION_MESSAGE,
-                                                          getImage(Config.imageBase + "32x32/question.png"),
+                                                          Util.QUESTION_ICON,
                                                           null, // use standard button titles
                                                           null);      // no default selection
 
@@ -1209,7 +1207,7 @@ public class StudioPanel extends JPanel implements Observer,WindowListener {
 
 
         saveFileAction = new UserAction(I18n.getString("Save"),
-                                        getImage(Config.imageBase2 + "disks.png"),
+                                        Util.DISKS_ICON,
                                         "Save the script",
                                         new Integer(KeyEvent.VK_S),
                                         KeyStroke.getKeyStroke(KeyEvent.VK_S,menuShortcutKeyMask)) {
@@ -1220,7 +1218,7 @@ public class StudioPanel extends JPanel implements Observer,WindowListener {
         };
 
         saveAsFileAction = new UserAction(I18n.getString("SaveAs"),
-                                          getImage(Config.imageBase2 + "save_as.png"),
+                                          Util.SAVE_AS_ICON,
                                           "Save script as",
                                           new Integer(KeyEvent.VK_A),
                                           null) {
@@ -1230,7 +1228,7 @@ public class StudioPanel extends JPanel implements Observer,WindowListener {
         };
 
         exportAction = new UserAction(I18n.getString("Export"),
-                                      getImage(Config.imageBase2 + "export2.png"),
+                                      Util.EXPORT_ICON,
                                       "Export result set",
                                       new Integer(KeyEvent.VK_E),
                                       null) {
@@ -1240,7 +1238,7 @@ public class StudioPanel extends JPanel implements Observer,WindowListener {
         };
 
         chartAction = new UserAction(I18n.getString("Chart"),
-                                     Util.getImage(Config.imageBase2 + "chart.png"),
+                                     Util.CHART_ICON,
                                      "Chart current data set",
                                      new Integer(KeyEvent.VK_E),
                                      null) {
@@ -1252,7 +1250,7 @@ public class StudioPanel extends JPanel implements Observer,WindowListener {
 
 
         stopAction = new UserAction(I18n.getString("Stop"),
-                                    getImage(Config.imageBase2 + "stop.png"),
+                                    Util.STOP_ICON,
                                     "Stop the query",
                                     new Integer(KeyEvent.VK_S),
                                     null) {
@@ -1267,7 +1265,7 @@ public class StudioPanel extends JPanel implements Observer,WindowListener {
 
 
         openInExcel = new UserAction(I18n.getString("OpenInExcel"),
-                                     getImage(Config.imageBase + "excel_icon.gif"),
+                                     Util.EXCEL_ICON,
                                      "Open in Excel",
                                      new Integer(KeyEvent.VK_O),
                                      null) {
@@ -1285,7 +1283,7 @@ public class StudioPanel extends JPanel implements Observer,WindowListener {
 
 
         executeAction = new UserAction(I18n.getString("Execute"),
-                                       Util.getImage(Config.imageBase2 + "table_sql_run.png"),
+                                       Util.TABLE_SQL_RUN_ICON,
                                        "Execute the full or highlighted text as a query",
                                        new Integer(KeyEvent.VK_E),
                                        KeyStroke.getKeyStroke(KeyEvent.VK_E,menuShortcutKeyMask)) {
@@ -1297,7 +1295,7 @@ public class StudioPanel extends JPanel implements Observer,WindowListener {
 
 
         executeCurrentLineAction = new UserAction(I18n.getString("ExecuteCurrentLine"),
-                                                  Util.getImage(Config.imageBase2 + "element_run.png"),
+                                                  Util.RUN_ICON,
                                                   "Execute the current line as a query",
                                                   new Integer(KeyEvent.VK_ENTER),
                                                   KeyStroke.getKeyStroke(KeyEvent.VK_ENTER,menuShortcutKeyMask)) {
@@ -1309,7 +1307,7 @@ public class StudioPanel extends JPanel implements Observer,WindowListener {
 
 
         refreshAction = new UserAction(I18n.getString("Refresh"),
-                                       getImage(Config.imageBase2 + "refresh.png"),
+                                       Util.REFRESH_ICON,
                                        "Refresh the result set",
                                        new Integer(KeyEvent.VK_R),
                                        KeyStroke.getKeyStroke(KeyEvent.VK_Y,menuShortcutKeyMask | Event.SHIFT_MASK)) {
@@ -1320,7 +1318,7 @@ public class StudioPanel extends JPanel implements Observer,WindowListener {
         };
 
         aboutAction = new UserAction(I18n.getString("About"),
-                                     Util.getImage(Config.imageBase2 + "about.png"),
+                                     Util.ABOUT_ICON,
                                      "About Studio for kdb+",
                                      new Integer(KeyEvent.VK_E),
                                      null) {
@@ -1331,7 +1329,7 @@ public class StudioPanel extends JPanel implements Observer,WindowListener {
         };
 
         exitAction = new UserAction(I18n.getString("Exit"),
-                                    getImage(Config.imageBase2 + "blank.png"),
+                                    Util.BLANK_ICON,
                                     "Close this window",
                                     new Integer(KeyEvent.VK_X),
                                     null) {
@@ -1343,7 +1341,7 @@ public class StudioPanel extends JPanel implements Observer,WindowListener {
         };
 
         settingsAction = new UserAction("Settings",
-                getImage(Config.imageBase2 + "blank.png"),
+                Util.BLANK_ICON,
                 "Settings",
                 new Integer(KeyEvent.VK_S),
                 null) {
@@ -1354,7 +1352,7 @@ public class StudioPanel extends JPanel implements Observer,WindowListener {
         };
 
         codeKxComAction = new UserAction("code.kx.com",
-                                         Util.getImage(Config.imageBase2 + "text.png"),
+                                         Util.TEXT_ICON,
                                          "Open code.kx.com",
                                          new Integer(KeyEvent.VK_C),
                                          null) {
@@ -1418,7 +1416,7 @@ public class StudioPanel extends JPanel implements Observer,WindowListener {
                                                       "Save changes?",
                                                       JOptionPane.YES_NO_CANCEL_OPTION,
                                                       JOptionPane.QUESTION_MESSAGE,
-                                                      getImage(Config.imageBase + "32x32/question.png"),
+                                                      Util.QUESTION_ICON,
                                                       null, // use standard button titles
                                                       null);      // no default selection
 
@@ -1494,7 +1492,7 @@ public class StudioPanel extends JPanel implements Observer,WindowListener {
 
                 JMenuItem item = new JMenuItem("" + (i + 1) + " " + filename);
                 item.setMnemonic(mnems[i]);
-                item.setIcon(getImage(Config.imageBase2 + "blank.png"));
+                item.setIcon(Util.BLANK_ICON);
                 item.addActionListener(new ActionListener() {
                     
                                        public void actionPerformed(ActionEvent e) {
@@ -1537,14 +1535,14 @@ public class StudioPanel extends JPanel implements Observer,WindowListener {
         Server[] servers = Config.getInstance().getServers();
         if (servers.length > 0) {
             JMenu subMenu = new JMenu(I18n.getString("Clone"));
-            subMenu.setIcon(Util.getImage(Config.imageBase2 + "data_copy.png"));
+            subMenu.setIcon(Util.DATA_COPY_ICON);
 
             int count = MAX_SERVERS_TO_CLONE;
             for (int i = 0;i < servers.length;i++) {
                 final Server s = servers[i];
                 if (!s.equals(server) && count <= 0) continue;
                 count--;
-                JMenuItem item = new JMenuItem(s.getName());
+                JMenuItem item = new JMenuItem(s.getFullName());
                 item.addActionListener(new ActionListener() {
                                         
                                        public void actionPerformed(ActionEvent e) {
@@ -1609,7 +1607,7 @@ public class StudioPanel extends JPanel implements Observer,WindowListener {
                         t = filename.replace('\\','/');
 
                     if (r.server != null)
-                        t = t + "[" + r.server.getName() + "]";
+                        t = t + "[" + r.server.getFullName() + "]";
                     else
                         t = t + "[no server]";
                 }
@@ -1631,9 +1629,9 @@ public class StudioPanel extends JPanel implements Observer,WindowListener {
                                    });
 
                 if (o == this)
-                    item.setIcon(getImage(Config.imageBase2 + "check2.png"));
+                    item.setIcon(Util.CHECK_ICON);
                 else
-                    item.setIcon(getImage(Config.imageBase2 + "blank.png"));
+                    item.setIcon(Util.BLANK_ICON);
 
                 menu.add(item);
                 i++;
@@ -1694,8 +1692,8 @@ public class StudioPanel extends JPanel implements Observer,WindowListener {
     }
 
     private void toolbarAddServerSelection() {
-        List<String> names = Config.getInstance().getServerNames();
-        String name = server == null ? "" : server.getName();
+        Collection<String> names = Config.getInstance().getServerNames();
+        String name = server == null ? "" : server.getFullName();
         if (!names.contains(name)) {
             List<String> newNames = new ArrayList<>();
             newNames.add(name);
@@ -1944,7 +1942,7 @@ public class StudioPanel extends JPanel implements Observer,WindowListener {
         frame.setLocation(((int) Math.max(0,(screenSize.width - frame.getWidth()) / 2.0)),
                           (int) (Math.max(0,(screenSize.height - frame.getHeight()) / 2.0)));
 
-        frame.setIconImage(getImage(Config.imageBase + "32x32/dot-chart.png").getImage());
+        frame.setIconImage(Util.LOGO_ICON.getImage());
 
         //     frame.pack();
         frame.setVisible(true);
@@ -2037,7 +2035,7 @@ public class StudioPanel extends JPanel implements Observer,WindowListener {
                                           "\nNo text available to submit to server.\n\n",
                                           "Studio for kdb+",
                                           JOptionPane.OK_OPTION,
-                                          getImage(Config.imageBase + "32x32/information.png"));
+                                          Util.INFORMATION_ICON);
 
             return;
         }
@@ -2130,7 +2128,7 @@ public class StudioPanel extends JPanel implements Observer,WindowListener {
                 chartAction.setEnabled(tableModel);
                 String title = tableModel ? "Table" : (dictModel ? "Dict" : "List");
                 TabPanel frame = new TabPanel( title + " [" + grid.getRowCount() + " rows] ",
-                        getImage(Config.imageBase2 + "table.png"),
+                        Util.TABLE_ICON,
                         grid);
 //                frame.setTitle(I18n.getString("Table")+" [" + grid.getRowCount() + " "+I18n.getString("rows")+"] ");
                 tabbedPane.addTab(frame.getTitle(),frame.getIcon(),frame.getComponent());
@@ -2159,7 +2157,7 @@ public class StudioPanel extends JPanel implements Observer,WindowListener {
                                                          ScrollPaneConstants.HORIZONTAL_SCROLLBAR_AS_NEEDED);
 
                 TabPanel frame = new TabPanel("Console View ",
-                                              getImage(Config.imageBase2 + "console.png"),
+                                              Util.CONSOLE_ICON,
                                               scrollpane);
 
                 frame.setTitle(I18n.getString("ConsoleView"));
@@ -2225,7 +2223,7 @@ public class StudioPanel extends JPanel implements Observer,WindowListener {
                                                           "\nA communications error occurred whilst sending the query.\n\nPlease check that the server is running on " + server.getHost() + ":" + server.getPort() + "\n\nError detail is\n\n" + ex.getMessage() + "\n\n",
                                                           "Studio for kdb+",
                                                           JOptionPane.ERROR_MESSAGE,
-                                                          getImage(Config.imageBase + "32x32/error.png"));
+                                                          Util.ERROR_ICON);
                         }
                         catch (c.K4Exception ex) {
                             JTextPane pane = new JTextPane();
@@ -2240,7 +2238,7 @@ public class StudioPanel extends JPanel implements Observer,WindowListener {
                             JScrollPane scrollpane = new JScrollPane(pane);
 
                             TabPanel frame = new TabPanel("Error Details ",
-                                                          getImage(Config.imageBase2 + "error.png"),
+                                                          Util.ERROR_SMALL_ICON,
                                                           scrollpane);
                             frame.setTitle("Error Details ");
 
@@ -2253,7 +2251,7 @@ public class StudioPanel extends JPanel implements Observer,WindowListener {
                                                           "\nOut of memory whilst communicating with " + server.getHost() + ":" + server.getPort() + "\n\nThe result set is probably too large.\n\nTry increasing the memory available to studio through the command line option -J -Xmx512m\n\n",
                                                           "Studio for kdb+",
                                                           JOptionPane.ERROR_MESSAGE,
-                                                          getImage(Config.imageBase + "32x32/error.png"));
+                                                          Util.ERROR_ICON);
                         }
                         catch (Throwable ex) {
                             String message = ex.getMessage();
@@ -2265,7 +2263,7 @@ public class StudioPanel extends JPanel implements Observer,WindowListener {
                                                           "\nAn unexpected error occurred whilst communicating with " + server.getHost() + ":" + server.getPort() + "\n\nError detail is\n\n" + message + "\n\n",
                                                           "Studio for kdb+",
                                                           JOptionPane.ERROR_MESSAGE,
-                                                          getImage(Config.imageBase + "32x32/error.png"));
+                                                          Util.ERROR_ICON);
                         }
                     else
                         try {
@@ -2277,7 +2275,7 @@ public class StudioPanel extends JPanel implements Observer,WindowListener {
                                                           "\nAn unexpected error occurred whilst communicating with " + server.getHost() + ":" + server.getPort() + "\n\nError detail is\n\n" + e.getMessage() + "\n\n",
                                                           "Studio for kdb+",
                                                           JOptionPane.ERROR_MESSAGE,
-                                                          getImage(Config.imageBase + "32x32/error.png"));
+                                                          Util.ERROR_ICON);
                         }
 
                     cleanup();
@@ -2380,27 +2378,5 @@ public class StudioPanel extends JPanel implements Observer,WindowListener {
         private static final String CREATED = "created";
         /** Document property holding Boolean modified information */
         private static final String MODIFIED = "modified";
-    }
-
-    public static ImageIcon getImage(String strFilename) {
-        Class thisClass = StudioPanel.class;
-
-        java.net.URL url = null;
-
-        if (strFilename.startsWith("/"))
-            url = thisClass.getResource(strFilename);
-        else
-            // Locate the desired image file and create a URL to it
-            url = thisClass.getResource("/toolbarButtonGraphics/" + strFilename);
-
-        // See if we successfully found the image
-        if (url == null)
-            //System.out.println("Unable to load the following image: " +
-            //                 strFilename);
-            return null;
-
-        Toolkit toolkit = Toolkit.getDefaultToolkit();
-        Image image = toolkit.getImage(url);
-        return new ImageIcon(image);
     }
 }

--- a/src/studio/ui/StudioPanel.java
+++ b/src/studio/ui/StudioPanel.java
@@ -1119,7 +1119,7 @@ public class StudioPanel extends JPanel implements Observer,WindowListener {
                             Config.getInstance().setServerListBounds(bounds);
 
                             Server selectedServer = serverList.getSelectedServer();
-                            if (selectedServer.equals(server)) return;
+                            if (selectedServer == null || selectedServer.equals(server)) return;
 
                             setServer(selectedServer);
                             rebuildToolbar();
@@ -1470,7 +1470,7 @@ public class StudioPanel extends JPanel implements Observer,WindowListener {
 
         menu.add(new JMenuItem(closeFileAction));
 
-        if (!MAC_OS_X) {
+        if (! Util.MAC_OS_X) {
             menu.add(new JMenuItem(settingsAction));
         }
         menu.addSeparator();
@@ -1503,7 +1503,7 @@ public class StudioPanel extends JPanel implements Observer,WindowListener {
             }
         }
 
-        if (!MAC_OS_X) {
+        if (! Util.MAC_OS_X) {
             menu.addSeparator();
             menu.add(new JMenuItem(exitAction));
         }
@@ -1641,7 +1641,7 @@ public class StudioPanel extends JPanel implements Observer,WindowListener {
         menu = new JMenu(I18n.getString("Help"));
         menu.setMnemonic(KeyEvent.VK_H);
         menu.add(new JMenuItem(codeKxComAction));
-        if (!MAC_OS_X)
+        if (! Util.MAC_OS_X)
             menu.add(new JMenuItem(aboutAction));
         menubar.add(menu);
 
@@ -1963,14 +1963,13 @@ public class StudioPanel extends JPanel implements Observer,WindowListener {
 
     public void update(Observable obs,Object obj) {
     }
-    public static boolean MAC_OS_X = (System.getProperty("os.name").toLowerCase().startsWith("mac os x"));
     private static boolean registeredForMaxOSXEvents = false;
 
     public void registerForMacOSXEvents() {
         if (registeredForMaxOSXEvents)
             return;
 
-        if (MAC_OS_X)
+        if (Util.MAC_OS_X)
             try {
                 // Generate and register the OSXAdapter, passing it a hash of all the methods we wish to
                 // use as delegates for various com.apple.eawt.ApplicationListener methods

--- a/src/studio/ui/StudioPanel.java
+++ b/src/studio/ui/StudioPanel.java
@@ -1375,6 +1375,8 @@ public class StudioPanel extends JPanel implements Observer,WindowListener {
         String auth = dialog.getDefaultAuthenticationMechanism();
         Config.getInstance().setDefaultAuthMechanism(auth);
         Config.getInstance().setDefaultCredentials(auth, new Credentials(dialog.getUser(), dialog.getPassword()));
+        Config.getInstance().setShowServerComboBox(dialog.isShowServerComboBox());
+        rebuildToolbar();
     }
 
     public void about() {
@@ -1704,8 +1706,11 @@ public class StudioPanel extends JPanel implements Observer,WindowListener {
         comboServer.setToolTipText("Select the server context");
         comboServer.setSelectedItem(name);
         comboServer.addActionListener(e->selectServerName());
+        // Cut the width if it is too wide.
+        comboServer.setMinimumSize(new Dimension(0, 0));
+        comboServer.setVisible(Config.getInstance().isShowServerComboBox());
 
-        txtServer = new JTextField();
+        txtServer = new JTextField(32);
         txtServer.addActionListener(e -> selectConnectionString());
         txtServer.addFocusListener(new FocusAdapter() {
             @Override

--- a/src/studio/ui/StudioPanel.java
+++ b/src/studio/ui/StudioPanel.java
@@ -7,6 +7,7 @@ import java.beans.PropertyChangeListener;
 import java.io.*;
 import java.util.*;
 import java.util.List;
+import java.util.stream.Stream;
 import javax.swing.*;
 import static javax.swing.JSplitPane.VERTICAL_SPLIT;
 import static studio.ui.EscapeDialog.DialogResult.ACCEPTED;
@@ -62,6 +63,7 @@ public class StudioPanel extends JPanel implements Observer,WindowListener {
     private JEditorPane textArea;
     private JSplitPane splitpane;
     private JTabbedPane tabbedPane;
+    private ServerList serverList;
     private Font font = null;
     private UserAction arrangeAllAction;
     private UserAction closeFileAction;
@@ -1090,8 +1092,34 @@ public class StudioPanel extends JPanel implements Observer,WindowListener {
                 new Integer(KeyEvent.VK_L),
                 KeyStroke.getKeyStroke(KeyEvent.VK_L, menuShortcutKeyMask | Event.SHIFT_MASK) ) {
                         public void actionPerformed(ActionEvent e) {
-                            ServerList serverList = new ServerList(frame, Config.getInstance().getServers(), server);
-                            serverList.alignAndShow();
+                            if (serverList == null) {
+
+                                Point location = frame.getLocation();
+                                GraphicsDevice devices[] = GraphicsEnvironment.getLocalGraphicsEnvironment().getScreenDevices();
+                                Rectangle screenBounds = Stream.of(devices)
+                                                                    .map(d -> d.getDefaultConfiguration().getBounds())
+                                                                    .filter(b -> b.contains(location))
+                                                                    .findFirst().orElse(null);
+
+                                Rectangle bounds = Config.getInstance().getServerListBounds();
+                                bounds.translate(frame.getX(), frame.getY());
+
+                                serverList = new ServerList(frame, Config.getInstance().getServers(), server);
+
+                                if (screenBounds != null && screenBounds.contains(bounds)) {
+                                    serverList.setBounds(bounds);
+                                    serverList.setVisible(true);
+                                } else {
+                                    serverList.alignAndShow();
+                                }
+                            } else {
+                                serverList.setVisible(true);
+                            }
+
+                            Rectangle bounds = serverList.getBounds();
+                            bounds.translate( -frame.getX(), -frame.getY());
+                            Config.getInstance().setServerListBounds(bounds);
+
                             Server selectedServer = serverList.getSelectedServer();
                             if (selectedServer.equals(server)) return;
 

--- a/src/studio/ui/UserAction.java
+++ b/src/studio/ui/UserAction.java
@@ -16,6 +16,14 @@ public abstract class UserAction extends AbstractAction {
         putValue(ACCELERATOR_KEY,key);
     }
 
+    public String getText() {
+        return (String)getValue(NAME);
+    }
+
+    public KeyStroke getKeyStroke() {
+        return (KeyStroke)getValue(ACCELERATOR_KEY);
+    }
+
     public static UserAction create(String text, ImageIcon icon,
                                String desc, int mnemonic,
                                KeyStroke key, ActionListener listener) {
@@ -45,4 +53,7 @@ public abstract class UserAction extends AbstractAction {
         return create(text, Util.BLANK_ICON, desc, mnemonic, null, listener);
     }
 
+    public static UserAction create(String text, ActionListener listener) {
+        return create(text, Util.BLANK_ICON, "", 0, null, listener);
+    }
 }

--- a/src/studio/ui/UserAction.java
+++ b/src/studio/ui/UserAction.java
@@ -1,6 +1,8 @@
 package studio.ui;
 
 import javax.swing.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
 
 public abstract class UserAction extends AbstractAction {
     public UserAction(String text,
@@ -13,4 +15,34 @@ public abstract class UserAction extends AbstractAction {
         putValue(MNEMONIC_KEY,mnemonic);
         putValue(ACCELERATOR_KEY,key);
     }
+
+    public static UserAction create(String text, ImageIcon icon,
+                               String desc, int mnemonic,
+                               KeyStroke key, ActionListener listener) {
+        return new UserAction(text, icon, desc, mnemonic, key) {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                listener.actionPerformed(e);
+            }
+        };
+    }
+
+    public static UserAction create(String text, ImageIcon icon,
+                             String desc, int mnemonic,
+                             ActionListener listener) {
+        return create(text, icon, desc, mnemonic, null, listener);
+    }
+
+    public static UserAction create(String text,
+                             String desc, int mnemonic,
+                             KeyStroke key, ActionListener listener) {
+        return create(text, Util.BLANK_ICON, desc, mnemonic, key, listener);
+    }
+
+    public static UserAction create(String text,
+                             String desc, int mnemonic,
+                             ActionListener listener) {
+        return create(text, Util.BLANK_ICON, desc, mnemonic, null, listener);
+    }
+
 }

--- a/src/studio/ui/Util.java
+++ b/src/studio/ui/Util.java
@@ -2,25 +2,65 @@ package studio.ui;
 
 import javax.swing.*;
 import java.awt.*;
+import java.net.URL;
 
 public class Util {
+    private final static String IMAGE_BASE = "/de/skelton/images/";
+    private final static String IMAGE_BASE2 = "/de/skelton/utils/";
+
+    public final static ImageIcon LOGO_ICON = getImage(IMAGE_BASE + "32x32/dot-chart.png");
+    public final static ImageIcon BLANK_ICON = getImage(IMAGE_BASE2 + "blank.png");
+    public final static ImageIcon QUESTION_ICON = getImage(IMAGE_BASE + "32x32/question.png");
+    public final static ImageIcon INFORMATION_ICON = getImage(IMAGE_BASE + "32x32/information.png");
+    public final static ImageIcon WARNING_ICON = getImage(IMAGE_BASE + "32x32/warning.png");
+    public final static ImageIcon ERROR_ICON = getImage(IMAGE_BASE + "32x32/error.png");
+    public final static ImageIcon ERROR_SMALL_ICON = getImage(IMAGE_BASE2 + "error.png");
+    public final static ImageIcon CHECK_ICON = getImage(IMAGE_BASE2 + "check2.png");
+
+    public final static ImageIcon UNDO_ICON = getImage(IMAGE_BASE2 + "undo.png");
+    public final static ImageIcon REDO_ICON =getImage(IMAGE_BASE2 + "redo.png");
+    public final static ImageIcon COPY_ICON = getImage(IMAGE_BASE2 + "copy.png");
+    public final static ImageIcon CUT_ICON = getImage(IMAGE_BASE2 + "cut.png");
+    public final static ImageIcon PASTE_ICON = getImage(IMAGE_BASE2 + "paste.png");
+    public final static ImageIcon NEW_DOCUMENT_ICON = getImage(IMAGE_BASE2 + "document_new.png");
+    public final static ImageIcon FIND_ICON = getImage(IMAGE_BASE2 + "find.png");
+    public final static ImageIcon REPLACE_ICON = getImage(IMAGE_BASE2 + "replace.png");
+    public final static ImageIcon FOLDER_ICON = getImage(IMAGE_BASE2 + "folder.png");
+    public final static ImageIcon TEXT_TREE_ICON = getImage(IMAGE_BASE + "text_tree.png");
+    public final static ImageIcon SERVER_INFORMATION_ICON = getImage(IMAGE_BASE2 + "server_information.png");
+    public final static ImageIcon ADD_SERVER_ICON = getImage(IMAGE_BASE2 + "server_add.png");
+    public final static ImageIcon DELETE_SERVER_ICON = getImage(IMAGE_BASE2 + "server_delete.png");
+    public final static ImageIcon DISKS_ICON = getImage(IMAGE_BASE2 + "disks.png");
+    public final static ImageIcon SAVE_AS_ICON = getImage(IMAGE_BASE2 + "save_as.png");
+    public final static ImageIcon EXPORT_ICON = getImage(IMAGE_BASE2 + "export2.png");
+    public final static ImageIcon CHART_ICON = getImage(IMAGE_BASE2 + "chart.png");
+    public final static ImageIcon STOP_ICON = getImage(IMAGE_BASE2 + "stop.png");
+    public final static ImageIcon EXCEL_ICON = getImage(IMAGE_BASE + "excel_icon.gif");
+    public final static ImageIcon TABLE_SQL_RUN_ICON = getImage(IMAGE_BASE2 + "table_sql_run.png");
+    public final static ImageIcon RUN_ICON = getImage(IMAGE_BASE2 + "element_run.png");
+    public final static ImageIcon REFRESH_ICON = getImage(IMAGE_BASE2 + "refresh.png");
+    public final static ImageIcon ABOUT_ICON = getImage(IMAGE_BASE2 + "about.png");
+    public final static ImageIcon TEXT_ICON = getImage(IMAGE_BASE2 + "text.png");
+    public final static ImageIcon TABLE_ICON = getImage(IMAGE_BASE2 + "table.png");
+    public final static ImageIcon CONSOLE_ICON = getImage(IMAGE_BASE2 + "console.png");
+    public final static ImageIcon DATA_COPY_ICON = getImage(IMAGE_BASE2 + "data_copy.png");
+    public final static ImageIcon CHART_BIG_ICON = Util.getImage(IMAGE_BASE2 + "chart_24.png");
+    public final static ImageIcon COLUMN_ICON = getImage(IMAGE_BASE2 +"column.png");
+    public final static ImageIcon SORT_ASC_ICON = getImage(IMAGE_BASE + "sort_ascending.png");
+    public final static ImageIcon SORT_AZ_ASC_ICON = getImage(IMAGE_BASE + "sort_az_ascending.png");
+    public final static ImageIcon SORT_DESC_ICON = getImage(IMAGE_BASE + "sort_descending.png");
+    public final static ImageIcon SORT_AZ_DESC_ICON = Util.getImage(IMAGE_BASE + "sort_az_descending.png");
+
     public static ImageIcon getImage(String strFilename) {
-        Class thisClass = Util.class;
+        if (!strFilename.startsWith("/")) {
+            strFilename = "/toolbarButtonGraphics/" + strFilename;
+        }
 
-        java.net.URL url = null;
-
-        if (strFilename.startsWith("/"))
-            url = thisClass.getResource(strFilename);
-        else
-            url = thisClass.getResource("/toolbarButtonGraphics/" + strFilename);
-
-        if (url == null)
-            return null;
+        URL url = Util.class.getResource(strFilename);
+        if (url == null) return null;
 
         Toolkit toolkit = Toolkit.getDefaultToolkit();
-
         Image image = toolkit.getImage(url);
-
         return new ImageIcon(image);
     }
 

--- a/src/studio/ui/Util.java
+++ b/src/studio/ui/Util.java
@@ -2,6 +2,7 @@ package studio.ui;
 
 import javax.swing.*;
 import java.awt.*;
+import java.awt.event.KeyEvent;
 import java.net.URL;
 
 public class Util {
@@ -51,6 +52,8 @@ public class Util {
     public final static ImageIcon SORT_DESC_ICON = getImage(IMAGE_BASE + "sort_descending.png");
     public final static ImageIcon SORT_AZ_DESC_ICON = Util.getImage(IMAGE_BASE + "sort_az_descending.png");
 
+    public static boolean MAC_OS_X = (System.getProperty("os.name").toLowerCase().startsWith("mac os x"));
+
     public static ImageIcon getImage(String strFilename) {
         if (!strFilename.startsWith("/")) {
             strFilename = "/toolbarButtonGraphics/" + strFilename;
@@ -77,4 +80,10 @@ public class Util {
 
         child.setLocation(x,y);
     }
+
+    public static String getAcceleratorString(KeyStroke keyStroke) {
+        return KeyEvent.getKeyModifiersText(keyStroke.getModifiers()) + (MAC_OS_X ? "": "+") +
+                KeyEvent.getKeyText(keyStroke.getKeyCode());
+    }
+
 }


### PR DESCRIPTION
**1) Persist position and size of Server List frame**
    
Server List window appears in the same place where it was closed previous time in the Studio window. In a new Studio window, Server List will be opened with the same size and the same location relative to the top left corner of the Studio window. If Server List can't be fit into the screen with the described algorithm, it will be opened with default position ans size. Relative location and size of Server List is persited into config file.

**2) Server List is now tree like**
    
Hierarchy for servers is added. By default (from Add Servers menu), servers are added into the top level into the end. Server List window has popup menu for adding new folders and for adding servers into folders. It is possible to have servers with the same name but wiht different parent folder. Server name (in menu, title, server selection combobox) is replaced with full server name (folder with server name joined with /). Format of config file is changed. Support of loading config in the old folder will be added later.

**3) Convert old format to new format with server tree**
    
Upgrade version in Config to 1.2. During the first start up with old config (with version 1.1), old format is converted to new format 1.2 and saved to disk.

**4) Server List: switch between tree and list like view**
    
A toggle button is added to a tool bar in Server List. In a list view, all servers are displayed with full path.

**5) Settings: adding an option to remove server drop down list from the toolbar**
    
Server drop down list in the toolbar can be optionally hidden. The option is added to the Settings menu. The option is persisted in the Config.