### PR TITLE
dz.3: Look and Feel / Multiple tabs / Syntax highlighting in output

### DIFF
--- a/src/studio/kdb/Config.java
+++ b/src/studio/kdb/Config.java
@@ -243,6 +243,15 @@ public class Config {
         save();
     }
 
+    public int getResultTabsCount() {
+        return Integer.parseInt(p.getProperty("resultTabsCount","5"));
+    }
+
+    public void setResultTabsCount(int value) {
+        p.setProperty("resultTabsCount", "" + value);
+        save();
+    }
+
     public void setServerListBounds(Rectangle rectangle) {
         p.setProperty("serverList.x", "" + (int)rectangle.getX());
         p.setProperty("serverList.y", "" + (int)rectangle.getY());

--- a/src/studio/kdb/Config.java
+++ b/src/studio/kdb/Config.java
@@ -252,6 +252,24 @@ public class Config {
         save();
     }
 
+    public int getMaxCharsInResult() {
+        return Integer.parseInt(p.getProperty("maxCharsInResult", "50000"));
+    }
+
+    public void setMaxCharsInResult(int value) {
+        p.setProperty("maxCharsInResult", "" + value);
+        save();
+    }
+
+    public int getMaxCharsInTableCell() {
+        return Integer.parseInt(p.getProperty("maxCharsInTableCell", "256"));
+    }
+
+    public void setMaxCharsInTableCell(int value) {
+        p.setProperty("maxCharsInTableCell", "" + value);
+        save();
+    }
+
     public void setServerListBounds(Rectangle rectangle) {
         p.setProperty("serverList.x", "" + (int)rectangle.getX());
         p.setProperty("serverList.y", "" + (int)rectangle.getY());

--- a/src/studio/kdb/K.java
+++ b/src/studio/kdb/K.java
@@ -1,7 +1,9 @@
 package studio.kdb;
 
+import java.io.CharArrayWriter;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.io.Writer;
 import java.lang.reflect.Array;
 import java.sql.Time;
 import java.sql.Timestamp;
@@ -90,7 +92,7 @@ public class K {
             return "";
         }
 
-        public void toString(LimitedWriter w, boolean showType) throws IOException {
+        public void toString(Writer w, boolean showType) throws IOException {
             w.write(toString(showType));
         }
 
@@ -125,7 +127,7 @@ public class K {
             type = 102;
         }
 
-        public void toString(LimitedWriter w, boolean showType) throws IOException {
+        public void toString(Writer w, boolean showType) throws IOException {
             w.write(getPrimitive());
         }
     }
@@ -153,7 +155,7 @@ public class K {
             type = 111;
         }
 
-        public void toString(LimitedWriter w, boolean showType) throws IOException {
+        public void toString(Writer w, boolean showType) throws IOException {
             o.toString(w, showType);
             w.write("\\:");
         }
@@ -165,7 +167,7 @@ public class K {
             type = 110;
         }
 
-        public void toString(LimitedWriter w, boolean showType) throws IOException {
+        public void toString(Writer w, boolean showType) throws IOException {
             o.toString(w, showType);
             w.write("/:");
         }
@@ -177,7 +179,7 @@ public class K {
             type = 109;
         }
 
-        public void toString(LimitedWriter w, boolean showType) throws IOException {
+        public void toString(Writer w, boolean showType) throws IOException {
             o.toString(w, showType);
             w.write("':");
         }
@@ -189,7 +191,7 @@ public class K {
             type = 106;
         }
 
-        public void toString(LimitedWriter w, boolean showType) throws IOException {
+        public void toString(Writer w, boolean showType) throws IOException {
             o.toString(w, showType);
             w.write("'");
         }
@@ -201,7 +203,7 @@ public class K {
             type = 107;
         }
 
-        public void toString(LimitedWriter w, boolean showType) throws IOException {
+        public void toString(Writer w, boolean showType) throws IOException {
             o.toString(w, showType);
             w.write("/");
         }
@@ -214,7 +216,7 @@ public class K {
             this.o = o;
         }
 
-        public void toString(LimitedWriter w, boolean showType) throws IOException {
+        public void toString(Writer w, boolean showType) throws IOException {
             o.toString(w, showType);
             w.write("\\");
         }
@@ -240,7 +242,7 @@ public class K {
             return body;
         }
 
-        public void toString(LimitedWriter w, boolean showType) throws IOException {
+        public void toString(Writer w, boolean showType) throws IOException {
             w.write(body);
         }
     }
@@ -280,7 +282,7 @@ public class K {
             this.objs = objs;
         }
 
-        public void toString(LimitedWriter w, boolean showType) throws IOException {
+        public void toString(Writer w, boolean showType) throws IOException {
             boolean listProjection = false;
             if ((objs.getLength() > 0) && (objs.at(0) instanceof UnaryPrimitive)) {
                 UnaryPrimitive up = (UnaryPrimitive) objs.at(0);
@@ -363,7 +365,7 @@ public class K {
             return primitive;
         }
 
-        public void toString(LimitedWriter w, boolean showType) throws IOException {
+        public void toString(Writer w, boolean showType) throws IOException {
             w.write(charVal);
         }
     }
@@ -376,7 +378,7 @@ public class K {
             type = 101;
         }
 
-        public void toString(LimitedWriter w, boolean showType) throws IOException {
+        public void toString(Writer w, boolean showType) throws IOException {
             if (getPrimitiveAsInt() == -1)
                 return;
             w.write(getPrimitive());
@@ -435,7 +437,7 @@ public class K {
             return s;
         }
 
-        public void toString(LimitedWriter w, boolean showType) throws IOException {
+        public void toString(Writer w, boolean showType) throws IOException {
             w.write(toString(showType));
         }
 
@@ -468,7 +470,7 @@ public class K {
             return "0x" + Integer.toHexString((b >> 4) & 0xf) + Integer.toHexString(b & 0xf);
         }
 
-        public void toString(LimitedWriter w, boolean showType) throws IOException {
+        public void toString(Writer w, boolean showType) throws IOException {
             w.write(toString(showType));
         }
     }
@@ -508,7 +510,7 @@ public class K {
             return t;
         }
 
-        public void toString(LimitedWriter w, boolean showType) throws IOException {
+        public void toString(Writer w, boolean showType) throws IOException {
             w.write(toString(showType));
         }
     }
@@ -548,7 +550,7 @@ public class K {
             return s;
         }
 
-        public void toString(LimitedWriter w, boolean showType) throws IOException {
+        public void toString(Writer w, boolean showType) throws IOException {
             w.write(toString(showType));
         }
     }
@@ -573,7 +575,7 @@ public class K {
             return s.length() == 0;
         }
 
-        public void toString(LimitedWriter w, boolean showType) throws IOException {
+        public void toString(Writer w, boolean showType) throws IOException {
             if (showType)
                 w.write("`");
             w.write(s);
@@ -621,7 +623,7 @@ public class K {
             return s;
         }
 
-        public void toString(LimitedWriter w, boolean showType) throws IOException {
+        public void toString(Writer w, boolean showType) throws IOException {
             w.write(toString(showType));
         }
 
@@ -654,7 +656,7 @@ public class K {
                 return "" + c;
         }
 
-        public void toString(LimitedWriter w, boolean showType) throws IOException {
+        public void toString(Writer w, boolean showType) throws IOException {
             w.write(toString(showType));
         }
 
@@ -703,7 +705,7 @@ public class K {
             }
         }
 
-        public void toString(LimitedWriter w, boolean showType) throws IOException {
+        public void toString(Writer w, boolean showType) throws IOException {
             w.write(toString(showType));
         }
 
@@ -753,7 +755,7 @@ public class K {
             }
         }
 
-        public void toString(LimitedWriter w, boolean showType) throws IOException {
+        public void toString(Writer w, boolean showType) throws IOException {
             w.write(toString(showType));
         }
 
@@ -791,7 +793,7 @@ public class K {
                 return sd("yyyy.MM.dd", new Date(86400000L * (date + 10957)));
         }
 
-        public void toString(LimitedWriter w, boolean showType) throws IOException {
+        public void toString(Writer w, boolean showType) throws IOException {
             w.write(toString(showType));
         }
 
@@ -822,7 +824,7 @@ public class K {
             return uuid.toString();
         }
 
-        public void toString(LimitedWriter w, boolean showType) throws IOException {
+        public void toString(Writer w, boolean showType) throws IOException {
             w.write(toString(showType));
         }
     }
@@ -854,7 +856,7 @@ public class K {
                 return sd("HH:mm:ss.SSS", new Time(time));
         }
 
-        public void toString(LimitedWriter w, boolean showType) throws IOException {
+        public void toString(Writer w, boolean showType) throws IOException {
             w.write(toString(showType));
         }
 
@@ -890,7 +892,7 @@ public class K {
                 return sd("yyyy.MM.dd HH:mm:ss.SSS", toTimestamp());
         }
 
-        public void toString(LimitedWriter w, boolean showType) throws IOException {
+        public void toString(Writer w, boolean showType) throws IOException {
             w.write(toString(showType));
         }
 
@@ -929,7 +931,7 @@ public class K {
             }
         }
 
-        public void toString(LimitedWriter w, boolean showType) throws IOException {
+        public void toString(Writer w, boolean showType) throws IOException {
             w.write(toString(showType));
         }
 
@@ -974,7 +976,7 @@ public class K {
             cy.append(updy);
         }
 
-        public void toString(LimitedWriter w, boolean showType) throws IOException {
+        public void toString(Writer w, boolean showType) throws IOException {
             boolean useBrackets = getAttr() != 0 || x instanceof Flip;
             super.toString(w, showType);
             if (useBrackets)
@@ -1001,7 +1003,7 @@ public class K {
             y = (K.KBaseVector) X.y;
         }
 
-        public void toString(LimitedWriter w, boolean showType) throws IOException {
+        public void toString(Writer w, boolean showType) throws IOException {
             boolean usebracket = x.getLength() == 1;
             w.write(flip);
             if (usebracket)
@@ -1058,7 +1060,7 @@ public class K {
             return cal.getTime();
         }
 
-        public void toString(LimitedWriter w, boolean showType) throws IOException {
+        public void toString(Writer w, boolean showType) throws IOException {
             w.write(toString(showType));
         }
     }
@@ -1090,7 +1092,7 @@ public class K {
                 return i2(i / 60) + ":" + i2(i % 60);
         }
 
-        public void toString(LimitedWriter w, boolean showType) throws IOException {
+        public void toString(Writer w, boolean showType) throws IOException {
             w.write(toString(showType));
         }
 
@@ -1129,7 +1131,7 @@ public class K {
                 return new Minute(i / 60).toString() + ':' + i2(i % 60);
         }
 
-        public void toString(LimitedWriter w, boolean showType) throws IOException {
+        public void toString(Writer w, boolean showType) throws IOException {
             w.write(toString(showType));
         }
 
@@ -1182,7 +1184,7 @@ public class K {
             }
         }
 
-        public void toString(LimitedWriter w, boolean showType) throws IOException {
+        public void toString(Writer w, boolean showType) throws IOException {
             w.write(toString(showType));
         }
 
@@ -1255,7 +1257,7 @@ public class K {
             return new KShort(Array.getShort(array, i));
         }
 
-        public void toString(LimitedWriter w, boolean showType) throws IOException {
+        public void toString(Writer w, boolean showType) throws IOException {
             w.write(super.toString(showType));
 
             if (getLength() == 0)
@@ -1297,7 +1299,7 @@ public class K {
             return new KInteger(Array.getInt(array, i));
         }
 
-        public void toString(LimitedWriter w, boolean showType) throws IOException {
+        public void toString(Writer w, boolean showType) throws IOException {
             w.write(super.toString(showType));
 
             if (getLength() == 0)
@@ -1338,7 +1340,7 @@ public class K {
             return (KBase) Array.get(array, i);
         }
 
-        public void toString(LimitedWriter w, boolean showType) throws IOException {
+        public void toString(Writer w, boolean showType) throws IOException {
             w.write(super.toString(showType));
 
             if (getLength() == 1)
@@ -1369,7 +1371,7 @@ public class K {
             return new KDouble(Array.getDouble(array, i));
         }
 
-        public void toString(LimitedWriter w, boolean showType) throws IOException {
+        public void toString(Writer w, boolean showType) throws IOException {
             w.write(super.toString(showType));
 
             if (getLength() == 0)
@@ -1421,7 +1423,7 @@ public class K {
             return new KFloat(Array.getFloat(array, i));
         }
 
-        public void toString(LimitedWriter w, boolean showType) throws IOException {
+        public void toString(Writer w, boolean showType) throws IOException {
             w.write(super.toString(showType));
 
             if (getLength() == 0)
@@ -1471,7 +1473,7 @@ public class K {
             return new KLong(Array.getLong(array, i));
         }
 
-        public void toString(LimitedWriter w, boolean showType) throws IOException {
+        public void toString(Writer w, boolean showType) throws IOException {
             w.write(super.toString(showType));
 
             if (getLength() == 0)
@@ -1513,7 +1515,7 @@ public class K {
             return new Month(Array.getInt(array, i));
         }
 
-        public void toString(LimitedWriter w, boolean showType) throws IOException {
+        public void toString(Writer w, boolean showType) throws IOException {
             w.write(super.toString(showType));
 
             if (getLength() == 0)
@@ -1557,7 +1559,7 @@ public class K {
             return new KDate(Array.getInt(array, i));
         }
 
-        public void toString(LimitedWriter w, boolean showType) throws IOException {
+        public void toString(Writer w, boolean showType) throws IOException {
             w.write(super.toString(showType));
 
             if (getLength() == 0)
@@ -1601,7 +1603,7 @@ public class K {
             return new KGuid((UUID) Array.get(array, i));
         }
 
-        public void toString(LimitedWriter w, boolean showType) throws IOException {
+        public void toString(Writer w, boolean showType) throws IOException {
             w.write(super.toString(showType));
 
             if (getLength() == 0)
@@ -1632,7 +1634,7 @@ public class K {
             return new Minute(Array.getInt(array, i));
         }
 
-        public void toString(LimitedWriter w, boolean showType) throws IOException {
+        public void toString(Writer w, boolean showType) throws IOException {
             w.write(super.toString(showType));
 
             if (getLength() == 0)
@@ -1671,7 +1673,7 @@ public class K {
             return new KDatetime(Array.getDouble(array, i));
         }
 
-        public void toString(LimitedWriter w, boolean showType) throws IOException {
+        public void toString(Writer w, boolean showType) throws IOException {
             w.write(super.toString(showType));
 
             if (getLength() == 0)
@@ -1717,7 +1719,7 @@ public class K {
             return new KTimestamp(Array.getLong(array, i));
         }
 
-        public void toString(LimitedWriter w, boolean showType) throws IOException {
+        public void toString(Writer w, boolean showType) throws IOException {
             w.write(super.toString(showType));
 
             if (getLength() == 0)
@@ -1748,7 +1750,7 @@ public class K {
             return new KTimespan(Array.getLong(array, i));
         }
 
-        public void toString(LimitedWriter w, boolean showType) throws IOException {
+        public void toString(Writer w, boolean showType) throws IOException {
             w.write(super.toString(showType));
 
             if (getLength() == 0)
@@ -1787,7 +1789,7 @@ public class K {
                 write(o, Array.getInt(array, i));
         }
 
-        public void toString(LimitedWriter w, boolean showType) throws IOException {
+        public void toString(Writer w, boolean showType) throws IOException {
             w.write(super.toString(showType));
 
             if (getLength() == 0)
@@ -1834,7 +1836,7 @@ public class K {
                 write(o, Array.getInt(array, i));
         }
 
-        public void toString(LimitedWriter w, boolean showType) throws IOException {
+        public void toString(Writer w, boolean showType) throws IOException {
             w.write(super.toString(showType));
 
             if (getLength() == 0)
@@ -1881,7 +1883,7 @@ public class K {
                 write(o, (byte) (Array.getBoolean(array, i) ? 1 : 0));
         }
 
-        public void toString(LimitedWriter w, boolean showType) throws IOException {
+        public void toString(Writer w, boolean showType) throws IOException {
             w.write(super.toString(showType));
             if (getLength() == 0)
                 w.write("`boolean$()");
@@ -1917,7 +1919,7 @@ public class K {
                 write(o, Array.getByte(array, i));
         }
 
-        public void toString(LimitedWriter w, boolean showType) throws IOException {
+        public void toString(Writer w, boolean showType) throws IOException {
             w.write(super.toString(showType));
             if (getLength() == 0)
                 w.write("`byte$()");
@@ -1948,7 +1950,7 @@ public class K {
             return new KSymbol((String) Array.get(array, i));
         }
 
-        public void toString(LimitedWriter w, boolean showType) throws IOException {
+        public void toString(Writer w, boolean showType) throws IOException {
             w.write(super.toString(showType));
             if (getLength() == 0)
                 w.write("0#`");
@@ -1995,7 +1997,7 @@ public class K {
             o.write(b);
         }
 
-        public void toString(LimitedWriter w, boolean showType) throws IOException {
+        public void toString(Writer w, boolean showType) throws IOException {
             w.write(super.toString(showType));
             if (getLength() == 1)
                 w.write(enlist);
@@ -2009,27 +2011,22 @@ public class K {
         }
 
         public String toString(boolean showType) {
+            CharArrayWriter w = new CharArrayWriter();
             try {
-                LimitedWriter lw = new LimitedWriter(256);
-                toString(lw, showType);
-                return lw.toString();
+                toString(w, showType);
             } catch (IOException e) {
-                StringBuilder sb = new StringBuilder(256);
-                if (getLength() == 1)
-                    sb.append(enlist);
-                sb.append('"').append((char[]) array).append('"');
-                return sb.toString();
+                e.printStackTrace(System.err);
             }
+            return w.toString();
         }
     }
 
     public static String decode(KBase obj, boolean showType) {
-        LimitedWriter w = new LimitedWriter(20000);
+        CharArrayWriter w = new CharArrayWriter();
         try {
             obj.toString(w, showType);
         } catch (IOException e) {
-            e.printStackTrace();
-        } catch (LimitedWriter.LimitException ex) {
+            e.printStackTrace(System.err);
         }
 
         return w.toString();

--- a/src/studio/kdb/KTableModel.java
+++ b/src/studio/kdb/KTableModel.java
@@ -25,7 +25,7 @@ public abstract class KTableModel extends AbstractTableModel {
             }
         }
 
-        if ((obj instanceof K.KBaseVector) && obj.type != 10) {
+        if ((obj instanceof K.KBaseVector) && obj.type != 10 && obj.type != 4) {
             return new ListModel((K.KBaseVector)obj);
         }
         return null;

--- a/src/studio/kdb/LimitedWriter.java
+++ b/src/studio/kdb/LimitedWriter.java
@@ -23,7 +23,9 @@ public class LimitedWriter extends CharArrayWriter {
 
     public void write(String s) throws IOException {
         if ((size() + s.length()) > limit) {
-            super.write(s.substring(0,limit - size()));
+            if (limit>size()) {
+                super.write(s.substring(0,limit - size()));
+            }
             super.write(" ... ");
             throw new LimitException();
         }

--- a/src/studio/kdb/Sorter.java
+++ b/src/studio/kdb/Sorter.java
@@ -233,6 +233,14 @@ public class Sorter {
             sort((byte[]) data,0,length - 1,permutation,scratch);
         else if (data instanceof String[])
             sort((String[]) data,0,length - 1,permutation,scratch);
+        else if (data instanceof K.KBase[]) {
+            K.KBase[] generalList = (K.KBase[]) data;
+            String[] list = new String[generalList.length];
+            for (int index = 0; index < generalList.length; index++) {
+                list[index] = generalList[index].toString(false);
+            }
+            sort(list,0, length-1, permutation, scratch);
+        }
 
         return permutation;
     }

--- a/src/studio/kdb/TableHeaderRenderer.java
+++ b/src/studio/kdb/TableHeaderRenderer.java
@@ -13,7 +13,7 @@ import javax.swing.table.DefaultTableCellRenderer;
 public class TableHeaderRenderer extends DefaultTableCellRenderer {
     public TableHeaderRenderer() {
         super();
-        setHorizontalAlignment(SwingConstants.RIGHT);
+        setHorizontalAlignment(SwingConstants.LEFT);
         setVerticalAlignment(SwingConstants.CENTER);
         setOpaque(true);
         final Border border = UIManager.getBorder("TableHeader.cellBorder");

--- a/src/studio/kdb/TableRowHeader.java
+++ b/src/studio/kdb/TableRowHeader.java
@@ -113,7 +113,10 @@ public class TableRowHeader extends JList {
             setHorizontalAlignment(RIGHT);
             setVerticalAlignment(CENTER);
             setOpaque(true);
-            setBorder(UIManager.getBorder("TableHeader.cellBorder"));
+            setBorder(BorderFactory.createCompoundBorder(
+                        UIManager.getBorder("TableHeader.cellBorder"),
+                        BorderFactory.createEmptyBorder(0,0,0,5)
+                      ));
             //setFont(UIManager.getFont("Table.font"));
             setFont(table.getFont());
             setBackground(UIManager.getColor("TableHeader.background"));

--- a/src/studio/ui/CellRenderer.java
+++ b/src/studio/ui/CellRenderer.java
@@ -1,5 +1,6 @@
 package studio.ui;
 
+import studio.kdb.Config;
 import studio.kdb.K;
 import studio.kdb.KTableModel;
 import studio.kdb.LimitedWriter;
@@ -20,7 +21,7 @@ class CellRenderer extends DefaultTableCellRenderer {
     private JTable table = null;
 
     private void initLabel(JTable table) {
-        setHorizontalAlignment(SwingConstants.RIGHT);
+        setHorizontalAlignment(SwingConstants.LEFT);
         setOpaque(true);
         int height = getPreferredSize().height;
 
@@ -57,7 +58,7 @@ class CellRenderer extends DefaultTableCellRenderer {
 
         if (value instanceof K.KBase) {
             K.KBase kb = (K.KBase) value;
-            LimitedWriter w = new LimitedWriter(256);
+            LimitedWriter w = new LimitedWriter(Config.getInstance().getMaxCharsInTableCell());
 
             try {
                 kb.toString(w,kb instanceof K.KBaseVector);
@@ -67,7 +68,6 @@ class CellRenderer extends DefaultTableCellRenderer {
             }
             catch (LimitedWriter.LimitException ex) {
             }
-            ;
 
             setText(w.toString());
             setForeground(kb.isNull() ? nullColor : fgColor);

--- a/src/studio/ui/ServerList.java
+++ b/src/studio/ui/ServerList.java
@@ -265,6 +265,7 @@ public class ServerList extends EscapeDialog implements TreeExpansionListener  {
         tglBtnBoxTree.setFocusable(false);
         tglBtnBoxTree.addActionListener(e->refreshServers());
         JToolBar toolbar = new JToolBar();
+        toolbar.setLayout(new BoxLayout(toolbar, BoxLayout.X_AXIS));
         toolbar.setFloatable(false);
         toolbar.add(tglBtnBoxTree);
         toolbar.addSeparator();

--- a/src/studio/ui/SettingsDialog.java
+++ b/src/studio/ui/SettingsDialog.java
@@ -6,6 +6,8 @@ import studio.kdb.Config;
 
 import javax.swing.*;
 import java.awt.*;
+import java.util.HashMap;
+import java.util.Map;
 
 import static javax.swing.GroupLayout.PREFERRED_SIZE;
 
@@ -14,6 +16,7 @@ public class SettingsDialog extends EscapeDialog {
     private JTextField txtUser;
     private JPasswordField txtPassword;
     private JCheckBox chBoxShowServerCombo;
+    private JComboBox comboBoxLookAndFeel;
     private JButton btnOk;
     private JButton btnCancel;
 
@@ -40,6 +43,10 @@ public class SettingsDialog extends EscapeDialog {
         return chBoxShowServerCombo.isSelected();
     }
 
+    public String getLookAndFeelClassName() {
+        return ((CustomiszedLookAndFeelInfo)comboBoxLookAndFeel.getSelectedItem()).getClassName();
+    }
+
     private void refreshCredentials() {
         Credentials credentials = Config.getInstance().getDefaultCredentials(getDefaultAuthenticationMechanism());
 
@@ -63,6 +70,15 @@ public class SettingsDialog extends EscapeDialog {
         comboBoxAuthMechanism.getModel().setSelectedItem(Config.getInstance().getDefaultAuthMechanism());
         comboBoxAuthMechanism.addItemListener(e -> refreshCredentials());
 
+        JLabel lblLookAndFeel = new JLabel("Look and Feel:");
+
+        LookAndFeels lookAndFeels = new LookAndFeels();
+        comboBoxLookAndFeel = new JComboBox(lookAndFeels.getLookAndFeels());
+        CustomiszedLookAndFeelInfo lf = lookAndFeels.getLookAndFeel(Config.getInstance().getLookAndFeel());
+        if (lf == null) {
+            lf = lookAndFeels.getLookAndFeel(UIManager.getLookAndFeel().getClass().getName());
+        }
+        comboBoxLookAndFeel.setSelectedItem(lf);
         chBoxShowServerCombo = new JCheckBox("Show server drop down list in the toolbar");
         JLabel lblAuthMechanism = new JLabel("Authentication:");
         JLabel lblUser = new JLabel("  User:");
@@ -70,6 +86,7 @@ public class SettingsDialog extends EscapeDialog {
 
         Component glue = Box.createGlue();
         Component glue1 = Box.createGlue();
+        Component glue2 = Box.createGlue();
 
         btnOk = new JButton("OK");
         btnCancel = new JButton("Cancel");
@@ -86,6 +103,12 @@ public class SettingsDialog extends EscapeDialog {
 
         layout.setHorizontalGroup(
                 layout.createParallelGroup()
+                        .addGroup(
+                            layout.createSequentialGroup()
+                                        .addComponent(lblLookAndFeel)
+                                        .addComponent(comboBoxLookAndFeel)
+                                        .addComponent(glue2)
+                        )
                         .addComponent(chBoxShowServerCombo)
                         .addGroup(
                             layout.createSequentialGroup()
@@ -107,7 +130,12 @@ public class SettingsDialog extends EscapeDialog {
 
         layout.setVerticalGroup(
                 layout.createSequentialGroup()
-                    .addComponent(chBoxShowServerCombo)
+                    .addGroup(
+                        layout.createParallelGroup(GroupLayout.Alignment.BASELINE)
+                                .addComponent(lblLookAndFeel)
+                                .addComponent(comboBoxLookAndFeel)
+                                .addComponent(glue2)
+                    ).addComponent(chBoxShowServerCombo)
                     .addGroup(
                         layout.createParallelGroup(GroupLayout.Alignment.BASELINE)
                                 .addComponent(lblAuthMechanism)
@@ -129,4 +157,31 @@ public class SettingsDialog extends EscapeDialog {
         setContentPane(root);
     }
 
+    private static class LookAndFeels {
+        private Map<String, CustomiszedLookAndFeelInfo> mapLookAndFeels;
+
+        public LookAndFeels() {
+            mapLookAndFeels = new HashMap<>();
+            for (UIManager.LookAndFeelInfo lf: UIManager.getInstalledLookAndFeels()) {
+                mapLookAndFeels.put(lf.getClassName(), new CustomiszedLookAndFeelInfo(lf));
+            }
+        }
+        public CustomiszedLookAndFeelInfo[] getLookAndFeels() {
+            return mapLookAndFeels.values().toArray(new CustomiszedLookAndFeelInfo[0]);
+        }
+        public CustomiszedLookAndFeelInfo getLookAndFeel(String className) {
+            return mapLookAndFeels.get(className);
+        }
+    }
+
+    private static class CustomiszedLookAndFeelInfo extends UIManager.LookAndFeelInfo {
+        public CustomiszedLookAndFeelInfo(UIManager.LookAndFeelInfo lfInfo) {
+            super(lfInfo.getName(), lfInfo.getClassName());
+        }
+
+        @Override
+        public String toString() {
+            return getName();
+        }
+    }
 }

--- a/src/studio/ui/SettingsDialog.java
+++ b/src/studio/ui/SettingsDialog.java
@@ -5,6 +5,7 @@ import studio.core.Credentials;
 import studio.kdb.Config;
 
 import javax.swing.*;
+import javax.swing.text.NumberFormatter;
 import java.awt.*;
 import java.util.HashMap;
 import java.util.Map;
@@ -17,6 +18,7 @@ public class SettingsDialog extends EscapeDialog {
     private JPasswordField txtPassword;
     private JCheckBox chBoxShowServerCombo;
     private JComboBox comboBoxLookAndFeel;
+    private JFormattedTextField txtTabsCount;
     private JButton btnOk;
     private JButton btnCancel;
 
@@ -45,6 +47,10 @@ public class SettingsDialog extends EscapeDialog {
 
     public String getLookAndFeelClassName() {
         return ((CustomiszedLookAndFeelInfo)comboBoxLookAndFeel.getSelectedItem()).getClassName();
+    }
+
+    public int getResultTabsCount() {
+        return (Integer) txtTabsCount.getValue();
     }
 
     private void refreshCredentials() {
@@ -79,6 +85,12 @@ public class SettingsDialog extends EscapeDialog {
             lf = lookAndFeels.getLookAndFeel(UIManager.getLookAndFeel().getClass().getName());
         }
         comboBoxLookAndFeel.setSelectedItem(lf);
+        JLabel lblResultTabsCount = new JLabel("Result tabs count");
+        NumberFormatter formatter = new NumberFormatter();
+        formatter.setMinimum(new Integer(1));
+        formatter.setAllowsInvalid(false);
+        txtTabsCount = new JFormattedTextField(formatter);
+        txtTabsCount.setValue(Config.getInstance().getResultTabsCount());
         chBoxShowServerCombo = new JCheckBox("Show server drop down list in the toolbar");
         JLabel lblAuthMechanism = new JLabel("Authentication:");
         JLabel lblUser = new JLabel("  User:");
@@ -109,8 +121,12 @@ public class SettingsDialog extends EscapeDialog {
                                         .addComponent(comboBoxLookAndFeel)
                                         .addComponent(glue2)
                         )
-                        .addComponent(chBoxShowServerCombo)
                         .addGroup(
+                            layout.createSequentialGroup()
+                                        .addComponent(lblResultTabsCount)
+                                        .addComponent(txtTabsCount)
+                                        .addComponent(chBoxShowServerCombo)
+                        ).addGroup(
                             layout.createSequentialGroup()
                                         .addComponent(lblAuthMechanism)
                                         .addComponent(comboBoxAuthMechanism, PREFERRED_SIZE, PREFERRED_SIZE, PREFERRED_SIZE)
@@ -135,8 +151,12 @@ public class SettingsDialog extends EscapeDialog {
                                 .addComponent(lblLookAndFeel)
                                 .addComponent(comboBoxLookAndFeel)
                                 .addComponent(glue2)
-                    ).addComponent(chBoxShowServerCombo)
-                    .addGroup(
+                    ).addGroup(
+                        layout.createParallelGroup(GroupLayout.Alignment.BASELINE)
+                                .addComponent(lblResultTabsCount)
+                                .addComponent(txtTabsCount)
+                                .addComponent(chBoxShowServerCombo)
+                    ).addGroup(
                         layout.createParallelGroup(GroupLayout.Alignment.BASELINE)
                                 .addComponent(lblAuthMechanism)
                                 .addComponent(comboBoxAuthMechanism)
@@ -152,7 +172,7 @@ public class SettingsDialog extends EscapeDialog {
                                 .addComponent(btnCancel)
                     )
         );
-        layout.linkSize(SwingConstants.HORIZONTAL, txtUser, txtPassword);
+        layout.linkSize(SwingConstants.HORIZONTAL, txtUser, txtPassword, txtTabsCount);
         layout.linkSize(SwingConstants.HORIZONTAL, btnOk, btnCancel);
         setContentPane(root);
     }

--- a/src/studio/ui/SettingsDialog.java
+++ b/src/studio/ui/SettingsDialog.java
@@ -19,6 +19,8 @@ public class SettingsDialog extends EscapeDialog {
     private JCheckBox chBoxShowServerCombo;
     private JComboBox comboBoxLookAndFeel;
     private JFormattedTextField txtTabsCount;
+    private JFormattedTextField txtMaxCharsInResult;
+    private JFormattedTextField txtMaxCharsInTableCell;
     private JButton btnOk;
     private JButton btnCancel;
 
@@ -51,6 +53,14 @@ public class SettingsDialog extends EscapeDialog {
 
     public int getResultTabsCount() {
         return (Integer) txtTabsCount.getValue();
+    }
+
+    public int getMaxCharsInResult() {
+        return (Integer) txtMaxCharsInResult.getValue();
+    }
+
+    public int getMaxCharsInTableCell() {
+        return (Integer) txtMaxCharsInTableCell.getValue();
     }
 
     private void refreshCredentials() {
@@ -92,6 +102,12 @@ public class SettingsDialog extends EscapeDialog {
         txtTabsCount = new JFormattedTextField(formatter);
         txtTabsCount.setValue(Config.getInstance().getResultTabsCount());
         chBoxShowServerCombo = new JCheckBox("Show server drop down list in the toolbar");
+        JLabel lblMaxCharsInResult = new JLabel("Max chars in result");
+        txtMaxCharsInResult = new JFormattedTextField(formatter);
+        txtMaxCharsInResult.setValue(Config.getInstance().getMaxCharsInResult());
+        JLabel lblMaxCharsInTableCell = new JLabel("Max chars in table cell");
+        txtMaxCharsInTableCell = new JFormattedTextField(formatter);
+        txtMaxCharsInTableCell.setValue(Config.getInstance().getMaxCharsInTableCell());
         JLabel lblAuthMechanism = new JLabel("Authentication:");
         JLabel lblUser = new JLabel("  User:");
         JLabel lblPassword = new JLabel("  Password:");
@@ -128,6 +144,12 @@ public class SettingsDialog extends EscapeDialog {
                                         .addComponent(chBoxShowServerCombo)
                         ).addGroup(
                             layout.createSequentialGroup()
+                                        .addComponent(lblMaxCharsInResult)
+                                        .addComponent(txtMaxCharsInResult)
+                                        .addComponent(lblMaxCharsInTableCell)
+                                        .addComponent(txtMaxCharsInTableCell)
+                        ).addGroup(
+                            layout.createSequentialGroup()
                                         .addComponent(lblAuthMechanism)
                                         .addComponent(comboBoxAuthMechanism, PREFERRED_SIZE, PREFERRED_SIZE, PREFERRED_SIZE)
                                         .addComponent(lblUser)
@@ -158,6 +180,12 @@ public class SettingsDialog extends EscapeDialog {
                                 .addComponent(chBoxShowServerCombo)
                     ).addGroup(
                         layout.createParallelGroup(GroupLayout.Alignment.BASELINE)
+                                .addComponent(lblMaxCharsInResult)
+                                .addComponent(txtMaxCharsInResult)
+                                .addComponent(lblMaxCharsInTableCell)
+                                .addComponent(txtMaxCharsInTableCell)
+                ).addGroup(
+                        layout.createParallelGroup(GroupLayout.Alignment.BASELINE)
                                 .addComponent(lblAuthMechanism)
                                 .addComponent(comboBoxAuthMechanism)
                                 .addComponent(lblUser)
@@ -172,7 +200,7 @@ public class SettingsDialog extends EscapeDialog {
                                 .addComponent(btnCancel)
                     )
         );
-        layout.linkSize(SwingConstants.HORIZONTAL, txtUser, txtPassword, txtTabsCount);
+        layout.linkSize(SwingConstants.HORIZONTAL, txtUser, txtPassword, txtTabsCount, txtMaxCharsInResult, txtMaxCharsInTableCell);
         layout.linkSize(SwingConstants.HORIZONTAL, btnOk, btnCancel);
         setContentPane(root);
     }

--- a/src/studio/ui/StudioPanel.java
+++ b/src/studio/ui/StudioPanel.java
@@ -1376,6 +1376,13 @@ public class StudioPanel extends JPanel implements Observer,WindowListener {
         Config.getInstance().setDefaultAuthMechanism(auth);
         Config.getInstance().setDefaultCredentials(auth, new Credentials(dialog.getUser(), dialog.getPassword()));
         Config.getInstance().setShowServerComboBox(dialog.isShowServerComboBox());
+
+        String lfClass = dialog.getLookAndFeelClassName();
+        if (!lfClass.equals(UIManager.getLookAndFeel().getClass().getName())) {
+            Config.getInstance().setLookAndFeel(lfClass);
+            JOptionPane.showMessageDialog(frame, "Look and Feel was changed. New L&F will take effect on the next start up.", "Look and Feel Setting Changed", JOptionPane.INFORMATION_MESSAGE);
+        }
+
         rebuildToolbar();
     }
 
@@ -1792,6 +1799,7 @@ public class StudioPanel extends JPanel implements Observer,WindowListener {
 
     private JToolBar createToolbar() {
         toolbar = new JToolBar();
+        toolbar.setLayout(new BoxLayout(toolbar, BoxLayout.X_AXIS));
         toolbar.setFloatable(false);
         rebuildToolbar();
         return toolbar;

--- a/src/studio/ui/StudioPanel.java
+++ b/src/studio/ui/StudioPanel.java
@@ -1376,6 +1376,7 @@ public class StudioPanel extends JPanel implements Observer,WindowListener {
         Config.getInstance().setDefaultAuthMechanism(auth);
         Config.getInstance().setDefaultCredentials(auth, new Credentials(dialog.getUser(), dialog.getPassword()));
         Config.getInstance().setShowServerComboBox(dialog.isShowServerComboBox());
+        Config.getInstance().setResultTabsCount(dialog.getResultTabsCount());
 
         String lfClass = dialog.getLookAndFeelClassName();
         if (!lfClass.equals(UIManager.getLookAndFeel().getClass().getName())) {
@@ -2180,6 +2181,7 @@ public class StudioPanel extends JPanel implements Observer,WindowListener {
         else {
             // Log that execute was successful
         }
+        tabbedPane.setSelectedIndex(tabbedPane.getTabCount()-1);
     }
     Server server = null;
 
@@ -2187,7 +2189,11 @@ public class StudioPanel extends JPanel implements Observer,WindowListener {
         final Cursor cursor = textArea.getCursor();
 
         textArea.setCursor(new java.awt.Cursor(java.awt.Cursor.WAIT_CURSOR));
-        tabbedPane.removeAll();
+
+          if(tabbedPane.getTabCount()>=Config.getInstance().getResultTabsCount()) {
+              tabbedPane.remove(0);
+          }
+
         worker = new SwingWorker() {
             Server s = null;
             c c = null;
@@ -2256,8 +2262,7 @@ public class StudioPanel extends JPanel implements Observer,WindowListener {
                             frame.setTitle("Error Details ");
 
                             tabbedPane.addTab(frame.getTitle(),frame.getIcon(),frame.getComponent());
-
-                        //            tabbedPane.setSelectedComponent(resultsTabbedPane);
+                            tabbedPane.setSelectedIndex(tabbedPane.getTabCount()-1);
                         }
                         catch (java.lang.OutOfMemoryError ex) {
                             JOptionPane.showMessageDialog(frame,

--- a/src/studio/ui/StudioPanel.java
+++ b/src/studio/ui/StudioPanel.java
@@ -64,7 +64,6 @@ public class StudioPanel extends JPanel implements Observer,WindowListener {
     private JSplitPane splitpane;
     private JTabbedPane tabbedPane;
     private ServerList serverList;
-    private Font font = null;
     private UserAction arrangeAllAction;
     private UserAction closeFileAction;
     private UserAction newFileAction;
@@ -1377,6 +1376,8 @@ public class StudioPanel extends JPanel implements Observer,WindowListener {
         Config.getInstance().setDefaultCredentials(auth, new Credentials(dialog.getUser(), dialog.getPassword()));
         Config.getInstance().setShowServerComboBox(dialog.isShowServerComboBox());
         Config.getInstance().setResultTabsCount(dialog.getResultTabsCount());
+        Config.getInstance().setMaxCharsInResult(dialog.getMaxCharsInResult());
+        Config.getInstance().setMaxCharsInTableCell(dialog.getMaxCharsInTableCell());
 
         String lfClass = dialog.getLookAndFeelClassName();
         if (!lfClass.equals(UIManager.getLookAndFeel().getClass().getName())) {
@@ -2148,7 +2149,7 @@ public class StudioPanel extends JPanel implements Observer,WindowListener {
             } else {
                 chartAction.setEnabled(false);
                 openInExcel.setEnabled(false);
-                LimitedWriter lm = new LimitedWriter(50000);
+                LimitedWriter lm = new LimitedWriter(Config.getInstance().getMaxCharsInResult());
                 try {
                   if(!(r instanceof K.UnaryPrimitive&&0==((K.UnaryPrimitive)r).getPrimitiveAsInt()))
                     r.toString(lm,true);
@@ -2159,19 +2160,13 @@ public class StudioPanel extends JPanel implements Observer,WindowListener {
                 catch (LimitedWriter.LimitException ex) {
                 }
 
-                JEditorPane pane = new JEditorPane("text/plain",lm.toString());
-                pane.setFont(font);
-
-//pane.setLineWrap( false);
-//pane.setWrapStyleWord( false);
-
-                JScrollPane scrollpane = new JScrollPane(pane,
-                                                         ScrollPaneConstants.VERTICAL_SCROLLBAR_AS_NEEDED,
-                                                         ScrollPaneConstants.HORIZONTAL_SCROLLBAR_AS_NEEDED);
+                JEditorPane textArea = new JEditorPane("text/q",lm.toString());
+                textArea.setEditable(false);
 
                 TabPanel frame = new TabPanel("Console View ",
-                                              Util.CONSOLE_ICON,
-                                              scrollpane);
+                        Util.CONSOLE_ICON,
+                        Utilities.getEditorUI(textArea).getExtComponent());
+
 
                 frame.setTitle(I18n.getString("ConsoleView"));
 
@@ -2289,6 +2284,7 @@ public class StudioPanel extends JPanel implements Observer,WindowListener {
                             processK4Results(r);
                         }
                         catch (Exception e) {
+                            e.printStackTrace(System.err);
                             JOptionPane.showMessageDialog(frame,
                                                           "\nAn unexpected error occurred whilst communicating with " + server.getHost() + ":" + server.getPort() + "\n\nError detail is\n\n" + e.getMessage() + "\n\n",
                                                           "Studio for kdb+",


### PR DESCRIPTION
**1) Selection of Look and Feel**

Adding an option to choose Look and Feel into Settings menu. Look and Feel is persisted to Config. The change to Look and Feel is taken effect only after restart.

**2) Multiple tabs in the result pane**

Now several results are kept in the result pane - by default, 5 last results are kept. Number of opened tabs is configured in Settings menu and persisted in Config.

**3) Syntax highlighting in output result and other improvements**
 
Non list output will have q syntax highlighting. For example, it is useful if output is a function.
Added configured limit of characters in output. There are two settings - one for table cells and another one for the whole output.
Table cells are aligned to left.
Fix sorting of strings and general lists.
Byte vectors are not format as list.
